### PR TITLE
[codex] Expand the knowledge base with migrated guidance

### DIFF
--- a/.agents/skills/add-to-knowledge-base/SKILL.md
+++ b/.agents/skills/add-to-knowledge-base/SKILL.md
@@ -11,24 +11,30 @@ Classify the material before choosing its destination.
 
 1. Resolve repository paths relative to this `SKILL.md`; the repository root is
    `../../..`.
-2. Read
+2. Apply the downstream-project-independence gate from [`AGENTS.md`](../../../AGENTS.md)
+   to every part intended for Knowledge or a usage Skill. Generalize
+   project-derived material only when it remains correct without its source
+   project; classify non-generalizable parts as neither and leave them in that
+   project.
+3. Read
    [`knowledge/agents/knowledge-and-skills.md`](../../../knowledge/agents/knowledge-and-skills.md),
    then classify every distinct part of the material as Knowledge, Skill,
    mixed, or neither using that model. Report why material in the last category
    was not integrated.
-3. For each Knowledge part, read
+4. For each Knowledge part, read
    [`references/add-knowledge.md`](references/add-knowledge.md) and complete
    that workflow.
-4. For each Skill part, read
+5. For each Skill part, read
    [`references/add-skill.md`](references/add-skill.md) and complete that
    workflow.
-5. For mixed material, finish the Knowledge branch first so the Skill can
+6. For mixed material, finish the Knowledge branch first so the Skill can
    reference the final canonical paths.
-6. Review the combined result and report the classification, changed paths,
+7. Review the combined result and report the classification, changed paths,
    and validation performed.
 
 ## Completion criteria
 
 Finish only when every part of the input has been classified, every accepted
 part has one authoritative home, the root Knowledge index and all references
-resolve, and the resulting diff preserves the Knowledge-versus-Skill boundary.
+resolve, every user-facing part preserves downstream-project independence, and
+the resulting diff preserves the Knowledge-versus-Skill boundary.

--- a/.agents/skills/add-to-knowledge-base/references/add-knowledge.md
+++ b/.agents/skills/add-to-knowledge-base/references/add-knowledge.md
@@ -5,19 +5,25 @@
    document Scopes and `When to Read` conditions for overlapping ownership.
 2. Work only from the Knowledge parts identified during classification; return
    the remaining material to the parent workflow.
-3. Update an existing document when it already owns the concept. Create a new
+3. Confirm that each Knowledge part remains correct without access to its
+   source project. Remove dependencies on named downstream repositories, fixed
+   project paths or layouts, project domain models, organization policies, and
+   private infrastructure. Product, platform, protocol, and engineering-domain
+   specificity are valid. Return material whose meaning depends on its source
+   project to the parent workflow as neither.
+4. Update an existing document when it already owns the concept. Create a new
    document only for a distinct responsibility, placing it in a clear domain
    under `knowledge/` with the smallest useful document structure.
-4. Give every Markdown document under `knowledge/`, including the root index,
+5. Give every Markdown document under `knowledge/`, including the root index,
    the required preface described below.
-5. Keep `knowledge/index.md` as the only index. Organize leaf documents in
+6. Keep `knowledge/index.md` as the only index. Organize leaf documents in
    domain directories, but list every leaf directly in the root index and do
    not create nested `index.md` files.
-6. Add or update exactly one root-index row for every affected leaf document
+7. Add or update exactly one root-index row for every affected leaf document
    using the fields below.
-7. Verify that every leaf document is listed exactly once, every changed
+8. Verify that every leaf document is listed exactly once, every changed
    relative link resolves, and each concept has one canonical owner.
-8. Run `pnpm knowledge:check` from the repository root.
+9. Run `pnpm knowledge:check` from the repository root.
 
 ## Knowledge document preface
 

--- a/.agents/skills/add-to-knowledge-base/references/add-skill.md
+++ b/.agents/skills/add-to-knowledge-base/references/add-skill.md
@@ -7,7 +7,13 @@
      after the `knowledge-base` plugin is installed.
    - Put an independent plugin's usage workflows inside that plugin's own
      `skills/` directory.
-2. Before adding or changing a repository-authoring or primary-plugin Skill,
+2. Test every usage workflow against an unknown downstream project. Discover
+   project paths, layouts, domain rules, organization policies, and
+   infrastructure from the Agent's active working directory rather than
+   hard-coding a particular project. Product, platform, protocol, and
+   engineering-domain specificity are valid. Return workflows that cannot be
+   made independent of their source project to the parent as neither.
+3. Before adding or changing a repository-authoring or primary-plugin Skill,
    read [`knowledge/index.md`](../../../../knowledge/index.md). Compare the
    workflow's decisions and required inputs with every `When to Read`
    condition, read every matching leaf document, and search `knowledge/` for
@@ -15,19 +21,19 @@
    Knowledge rather than reproducing it. If required reusable Knowledge is
    missing, return that material to the parent workflow as mixed and complete
    the Knowledge branch first.
-3. Search the selected Skill scope for an existing workflow with the same
+4. Search the selected Skill scope for an existing workflow with the same
    responsibility. Extend the existing Skill when it already owns the task.
-4. For a new Skill, use a lowercase hyphenated, verb-led directory name that
+5. For a new Skill, use a lowercase hyphenated, verb-led directory name that
    matches its frontmatter `name`. Write a `description` that states both the
    capability and the concrete trigger branches.
-5. Keep the body procedural and imperative. Move branch-specific detail into
+6. Keep the body procedural and imperative. Move branch-specific detail into
    `references/` when progressive disclosure keeps the main workflow focused.
-6. For every usage Skill that applies Knowledge, encode working-directory
+7. For every usage Skill that applies Knowledge, encode working-directory
    precedence: treat shared Knowledge as supplemental guidance and follow
    instructions, Skills, requirements, and project-specific information from
    the Agent's active working directory when they conflict with shared
    Knowledge.
-7. Keep ordinary usage Skills valid after installation: reference only files
+8. Keep ordinary usage Skills valid after installation: reference only files
    inside their plugin package and avoid dependencies on `.agents/`, repository
    tooling, or Skill-to-Skill invocation. A contribution Skill may use the
    primary manifest's canonical repository URL to create an isolated source
@@ -35,6 +41,7 @@
    checkout; it must not treat the installed plugin's `.agents/` or files as
    the authoring target. Keep independent plugins fully self-contained and do
    not reference root Knowledge.
-8. Validate the Skill frontmatter, referenced paths, repository formatting,
+9. Validate the Skill frontmatter, referenced paths, repository formatting,
    and relevant tests. Confirm that the Skill is in the scope selected in step
-   1 and has no duplicated source of truth.
+   1, preserves downstream-project independence when user-facing, and has no
+   duplicated source of truth.

--- a/.agents/skills/add-to-knowledge-base/references/add-skill.md
+++ b/.agents/skills/add-to-knowledge-base/references/add-skill.md
@@ -7,27 +7,34 @@
      after the `knowledge-base` plugin is installed.
    - Put an independent plugin's usage workflows inside that plugin's own
      `skills/` directory.
-2. Search the selected Skill scope for an existing workflow with the same
+2. Before adding or changing a repository-authoring or primary-plugin Skill,
+   read [`knowledge/index.md`](../../../../knowledge/index.md). Compare the
+   workflow's decisions and required inputs with every `When to Read`
+   condition, read every matching leaf document, and search `knowledge/` for
+   concepts the Skill would otherwise explain. Reference applicable canonical
+   Knowledge rather than reproducing it. If required reusable Knowledge is
+   missing, return that material to the parent workflow as mixed and complete
+   the Knowledge branch first.
+3. Search the selected Skill scope for an existing workflow with the same
    responsibility. Extend the existing Skill when it already owns the task.
-3. For a new Skill, use a lowercase hyphenated, verb-led directory name that
+4. For a new Skill, use a lowercase hyphenated, verb-led directory name that
    matches its frontmatter `name`. Write a `description` that states both the
    capability and the concrete trigger branches.
-4. Keep the body procedural and imperative. Reference the canonical Knowledge
-   selected during classification instead of copying it into the Skill. Move
-   branch-specific detail into `references/` when progressive disclosure keeps
-   the main workflow focused.
-5. For every usage Skill that applies Knowledge, encode working-directory
+5. Keep the body procedural and imperative. Move branch-specific detail into
+   `references/` when progressive disclosure keeps the main workflow focused.
+6. For every usage Skill that applies Knowledge, encode working-directory
    precedence: treat shared Knowledge as supplemental guidance and follow
    instructions, Skills, requirements, and project-specific information from
    the Agent's active working directory when they conflict with shared
    Knowledge.
-6. Keep ordinary usage Skills valid after installation: reference only files
+7. Keep ordinary usage Skills valid after installation: reference only files
    inside their plugin package and avoid dependencies on `.agents/`, repository
    tooling, or Skill-to-Skill invocation. A contribution Skill may use the
    primary manifest's canonical repository URL to create an isolated source
    checkout and read authoring instructions from `.agents/` inside that
    checkout; it must not treat the installed plugin's `.agents/` or files as
-   the authoring target. Keep independent plugins fully self-contained.
-7. Validate the Skill frontmatter, referenced paths, repository formatting,
+   the authoring target. Keep independent plugins fully self-contained and do
+   not reference root Knowledge.
+8. Validate the Skill frontmatter, referenced paths, repository formatting,
    and relevant tests. Confirm that the Skill is in the scope selected in step
    1 and has no duplicated source of truth.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,15 @@ the static content under `knowledge/`, and **Skill** means an Agent workflow.
   this repository.
 - `skills/` contains workflows used after installing the primary plugin.
 
+Knowledge and installed usage Skills must preserve **downstream-project
+independence**. They may target a product, platform, protocol, or engineering
+domain, but must not require a particular downstream repository, path layout,
+domain model, organization policy, or private infrastructure. Generalize
+material extracted from a project only when it remains correct without that
+project; otherwise leave it in the source project. Repository-authoring Skills
+are outside this user-facing boundary; the narrow contribution exception is
+described below.
+
 ## Skill scopes
 
 Choose a Skill's location by its audience and lifecycle, not by its subject.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Install the primary `knowledge-base` plugin and work normally. Its catalog Skill
 - **Knowledge** records reusable facts, concepts, principles, constraints, explanations, and references. [`knowledge/index.md`](knowledge/index.md) is its only routing catalog.
 - **Skills** tell an Agent when and how to perform a task. They may read canonical Knowledge instead of duplicating it.
 
+User-facing Knowledge and Skills are independent of any particular downstream project. They may target a general product, platform, protocol, or engineering domain, while discovering project-specific structure and requirements from the Agent's active working directory.
+
 The repository root is the primary plugin. Its Knowledge lives in `knowledge/`, and its portable Agent workflows live in `skills/`. Independent, self-contained plugins may also be added under `plugins/`.
 
 See [Knowledge and Skills](knowledge/agents/knowledge-and-skills.md) for the complete distinction.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # knowledge-base
 
-A personal collection of reusable knowledge and Agent workflows, distributed
-as plugins for Codex and GitHub Copilot CLI.
+A personal, curated knowledge base for Codex and GitHub Copilot CLI. It combines reusable Knowledge with Agent Skills that discover, apply, and maintain that Knowledge during real tasks.
 
-The repository root is the primary `knowledge-base` plugin. Canonical static
-content lives in `knowledge/`, while `skills/` provides Agent-facing retrieval
-and workflow entry points. Independent, self-contained plugins may also live in
-`plugins/`.
+Install the primary `knowledge-base` plugin and work normally. Its catalog Skill checks which Knowledge may apply, then reads only the matching documents. Knowledge from this repository is supplemental: instructions, requirements, context, and Skills in the Agent's active working directory take precedence when they conflict.
+
+## How it works
+
+- **Knowledge** records reusable facts, concepts, principles, constraints, explanations, and references. [`knowledge/index.md`](knowledge/index.md) is its only routing catalog.
+- **Skills** tell an Agent when and how to perform a task. They may read canonical Knowledge instead of duplicating it.
+
+The repository root is the primary plugin. Its Knowledge lives in `knowledge/`, and its portable Agent workflows live in `skills/`. Independent, self-contained plugins may also be added under `plugins/`.
+
+See [Knowledge and Skills](knowledge/agents/knowledge-and-skills.md) for the complete distinction.
 
 ## Install with Codex
 
@@ -14,6 +19,14 @@ Add the marketplace, then install the primary plugin:
 
 ```bash
 codex plugin marketplace add Soulike/knowledge-base
+codex plugin add knowledge-base@knowledge-base
+```
+
+To update an existing installation, refresh the marketplace snapshot and reinstall the plugin:
+
+```bash
+codex plugin marketplace upgrade knowledge-base
+codex plugin remove knowledge-base@knowledge-base
 codex plugin add knowledge-base@knowledge-base
 ```
 
@@ -26,6 +39,51 @@ copilot plugin marketplace add Soulike/knowledge-base
 copilot plugin marketplace browse knowledge-base
 copilot plugin install knowledge-base@knowledge-base
 ```
+
+To update an existing installation:
+
+```bash
+copilot plugin marketplace update knowledge-base
+copilot plugin update knowledge-base@knowledge-base
+```
+
+Start a new Agent session after installing or updating so the client can discover the current Skills.
+
+## Use the knowledge base
+
+No special command or repository path is required in normal use. Describe the task to the Agent as usual; [`load-knowledge-catalog`](skills/load-knowledge-catalog/SKILL.md) checks the catalog at the beginning of the task and routes the Agent to relevant Knowledge.
+
+You can also ask explicitly when you want to inspect or control that process:
+
+- “Load the Knowledge catalog and tell me which entries apply to this task.”
+- “Use the knowledge base while configuring Codex for GitHub Copilot Enterprise.”
+- “Contribute this correction to the knowledge base.”
+
+## Browse the contents
+
+- [Knowledge catalog](knowledge/index.md): the canonical list of Knowledge and its read conditions.
+- [`load-knowledge-catalog`](skills/load-knowledge-catalog/SKILL.md): discovers and loads relevant Knowledge.
+- [`contribute-to-knowledge-base`](skills/contribute-to-knowledge-base/SKILL.md): adds, corrects, reorganizes, or removes canonical Knowledge and Skills.
+- [`retry-via-local-proxy`](skills/retry-via-local-proxy/SKILL.md): retries failed read-only network retrieval through a detected local proxy.
+
+## Contribute
+
+The easiest route is to ask an Agent to contribute a change to the knowledge base. The installed [`contribute-to-knowledge-base`](skills/contribute-to-knowledge-base/SKILL.md) Skill locates the canonical repository and follows its authoring and validation workflow.
+
+For a manual source checkout, use Node.js 24 or later and pnpm 11:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm check
+```
+
+Run `pnpm check` before opening a pull request. Repository conventions for Agent-assisted changes live in [`AGENTS.md`](AGENTS.md), while the reusable content boundary is defined in [Knowledge and Skills](knowledge/agents/knowledge-and-skills.md).
+
+## Compatibility
+
+The repository targets Codex and GitHub Copilot CLI and packages plugins using the Agent Plugins v1 format. Claude Code compatibility is outside its scope.
+
+This is a personal, curated collection rather than official OpenAI, GitHub, or third-party product documentation. Follow the active project's requirements and verify current upstream behavior when it can change over time.
 
 ## License
 

--- a/knowledge/codex/github-copilot-enterprise-provider.md
+++ b/knowledge/codex/github-copilot-enterprise-provider.md
@@ -1,0 +1,59 @@
+# GitHub Copilot Enterprise provider for Codex
+
+## Scope
+
+This document records a verified Codex custom-provider configuration for using models made available through a GitHub Copilot Enterprise subscription. It covers the provider endpoint and protocol, command-backed GitHub authentication, model selection boundaries, secret handling, and failure classification; GitHub enterprise provisioning, model recommendations, and unrelated transport, retry, timeout, or WebSocket tuning are outside its scope.
+
+## When to update
+
+Update this document when Codex changes its custom-provider or command-backed authentication schema, GitHub changes the Copilot Enterprise endpoint or its Responses API compatibility, the GitHub CLI changes how credentials are obtained, or observed model discovery, access, or error behavior no longer matches the guidance here.
+
+## Preconditions
+
+The GitHub account authenticated by the GitHub CLI for `github.com` must have access to the relevant Copilot Enterprise subscription and model. Confirm the selected account with `gh auth status -h github.com`. Authentication and subscription access are separate from the Codex configuration: a syntactically valid provider does not grant either one.
+
+Codex supports custom model providers and command-backed authentication as general configuration mechanisms. The GitHub-specific endpoint and combination below are based on verified operation rather than an OpenAI guarantee about GitHub Copilot Enterprise compatibility.
+
+## Configuration
+
+Add the following configuration to `~/.codex/config.toml`, replacing the model placeholder with an identifier currently available to the authenticated account:
+
+```toml
+model_provider = "github-copilot-enterprise"
+model = "<currently-supported-model>"
+
+[model_providers.github-copilot-enterprise]
+name = "GitHub Copilot Enterprise"
+base_url = "https://api.enterprise.githubcopilot.com"
+wire_api = "responses"
+
+[model_providers.github-copilot-enterprise.auth]
+command = "gh"
+args = ["auth", "token", "-h", "github.com"]
+```
+
+The top-level `model_provider` selects the custom provider. `wire_api = "responses"` makes Codex use the Responses protocol expected by this endpoint. The nested `auth` table makes Codex obtain the credential from the GitHub CLI instead of storing a token in the configuration file.
+
+## Select a model from current availability
+
+Treat model identifiers as dynamic provider and account state. Resolve the model from current GitHub Copilot model availability and the enterprise policy applied to the authenticated account; do not infer it from Codex defaults, remembered model names, or another account's access. Keep the placeholder in reusable examples rather than turning a model that worked once into a durable recommendation.
+
+A provider connection can authenticate successfully while rejecting the configured model. Classify a model-not-found or model-access error separately from endpoint and authentication failures, then verify the identifier, subscription availability, and enterprise policy before changing the provider configuration.
+
+## Protect the credential boundary
+
+The authentication command must write only the credential expected by Codex to standard output. Do not copy the output of `gh auth token -h github.com` into `config.toml`, documentation, logs, issues, or pull requests. Prefer `gh auth status -h github.com` when checking login state because it verifies the selected host and account without printing the token.
+
+If the command fails, repair the GitHub CLI login for `github.com` rather than replacing command-backed authentication with a hard-coded credential. A `401` or `403` after the command succeeds can instead indicate expired or insufficient credentials, missing Copilot Enterprise entitlement, enterprise policy, or endpoint access.
+
+## Diagnose by boundary
+
+After changing the configuration, start a new Codex session and make a small request through the provider. Diagnose failures at the boundary indicated by the evidence:
+
+- A command execution or empty-credential error belongs to GitHub CLI authentication.
+- An HTTP `401` or `403` belongs to credential, entitlement, policy, or endpoint authorization.
+- A model-not-found or model-access error belongs to current model availability or enterprise policy.
+- A request-shape or unsupported-protocol error belongs to Responses API compatibility and `wire_api` configuration.
+- Connection stability, retry counts, timeouts, and WebSocket support are separate transport concerns and should not be added to this provider setup without independent evidence.
+
+Do not change several boundaries at once. Preserve the verified endpoint, protocol, and dynamic authentication while testing the failing boundary independently.

--- a/knowledge/github-actions/version-selection.md
+++ b/knowledge/github-actions/version-selection.md
@@ -1,0 +1,25 @@
+# GitHub Actions version selection
+
+## Scope
+
+This document defines how to verify and select versions for third-party actions, runtimes, and tools declared in GitHub Actions workflows. It covers source freshness, compatibility with the active repository, version-reference policy, and failure behavior when current upstream information cannot be verified; dependency management outside workflow files and step-specific configuration are outside its scope.
+
+## When to update
+
+Update this document when GitHub Actions, upstream release channels, or repository pinning practices change how current versions are discovered or evaluated, or when a real workflow change exposes an unhandled verification, compatibility, or failure case.
+
+## Verify current upstream state
+
+Verify the current upstream state before writing, retaining, or recommending a version in a created, edited, or reviewed workflow. Model memory, cached examples, search-result snippets, and version references copied from unrelated repositories may identify candidates, but they do not establish what is current.
+
+Open an authoritative source during the task. For an action, consult its publisher's official repository, releases, tags, and documentation. For a runtime or tool, consult its official release and support information together with the documentation for the action that installs or configures it. Establish the current stable or supported release line, confirm that the exact proposed reference exists, and distinguish retrieved facts from inference.
+
+## Select in repository context
+
+Treat the latest verified release as an input to version selection, not as an unconditional target. Follow requirements and version policy in the active working directory, including compatibility constraints, supported runner environments, runtime declarations, immutable-SHA or moving-tag conventions, and intentional pins. Check breaking changes before crossing a major or support boundary.
+
+Use the latest verified compatible version when the repository does not impose a different constraint. Preserve the repository's reference style and explain any deliberate choice not to use the latest available release. A version already present in the workflow is evidence of repository state, not proof that the upstream reference remains current or supported.
+
+## Handle verification failure
+
+Never invent a version when current upstream information cannot be verified. For a workflow edit that does not require a version change, preserve the existing reference and report that its freshness remains unverified. When the task requires adding or changing a version, report the verification blocker instead of committing a guessed value.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -10,7 +10,8 @@ Update this index when a leaf Knowledge document is added, removed, renamed, or 
 
 ## Documents
 
-| File Path                                                                            | When to Read                                                                                                                      |
-| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| [knowledge/agents/knowledge-and-skills.md](agents/knowledge-and-skills.md)           | Read when deciding whether reusable Agent material should be represented as Knowledge, a Skill, or a split of both.               |
-| [knowledge/github-actions/version-selection.md](github-actions/version-selection.md) | Read when creating, editing, or reviewing a GitHub Actions workflow that declares a third-party action, runtime, or tool version. |
+| File Path                                                                                            | When to Read                                                                                                                      |
+| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| [knowledge/agents/knowledge-and-skills.md](agents/knowledge-and-skills.md)                           | Read when deciding whether reusable Agent material should be represented as Knowledge, a Skill, or a split of both.               |
+| [knowledge/codex/github-copilot-enterprise-provider.md](codex/github-copilot-enterprise-provider.md) | Read when configuring or troubleshooting Codex to use a GitHub Copilot Enterprise subscription as a custom model provider.        |
+| [knowledge/github-actions/version-selection.md](github-actions/version-selection.md)                 | Read when creating, editing, or reviewing a GitHub Actions workflow that declares a third-party action, runtime, or tool version. |

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -10,6 +10,7 @@ Update this index when a leaf Knowledge document is added, removed, renamed, or 
 
 ## Documents
 
-| File Path                                                                  | When to Read                                                                                                        |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| [knowledge/agents/knowledge-and-skills.md](agents/knowledge-and-skills.md) | Read when deciding whether reusable Agent material should be represented as Knowledge, a Skill, or a split of both. |
+| File Path                                                                            | When to Read                                                                                                                      |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| [knowledge/agents/knowledge-and-skills.md](agents/knowledge-and-skills.md)           | Read when deciding whether reusable Agent material should be represented as Knowledge, a Skill, or a split of both.               |
+| [knowledge/github-actions/version-selection.md](github-actions/version-selection.md) | Read when creating, editing, or reviewing a GitHub Actions workflow that declares a third-party action, runtime, or tool version. |

--- a/skills/retry-via-local-proxy/SKILL.md
+++ b/skills/retry-via-local-proxy/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: retry-via-local-proxy
+description: Retry read-only network fetches through a detected local HTTP or SOCKS5 proxy on 127.0.0.1 ports 1087 and 1080. Use after direct web, documentation, API, package metadata, clone, or download requests fail with connection, DNS, timeout, TLS, or HTTP 403 errors.
+---
+
+# Retry Via Local Proxy
+
+Treat a local proxy as a bounded fallback for the same retrieval, not as a
+persistent network setting.
+
+## Workflow
+
+1. Record the direct failure and confirm that replay is safe. Retry `GET`,
+   `HEAD`, list, clone, and download operations automatically. Ask before
+   replaying `POST`, `PUT`, `PATCH`, `DELETE`, uploads, or commands with side
+   effects. Preserve the target, request semantics, headers, and credentials;
+   keep secrets out of logs.
+
+2. Probe these candidates once each with short timeouts:
+
+   - `http://127.0.0.1:1087`
+   - `socks5h://127.0.0.1:1087`
+   - `socks5h://127.0.0.1:1080`
+   - `http://127.0.0.1:1080`
+
+   Test the proxy protocol against the same target or its origin. A listening
+   TCP port alone is insufficient. With curl, use a read-only probe such as:
+
+   ```bash
+   curl --silent --show-error --output /dev/null \
+     --connect-timeout 2 --max-time 10 \
+     --proxy "$proxy" --head "$target"
+   ```
+
+   Treat a completed proxy negotiation or an origin HTTP response as evidence
+   that the candidate is usable. If the target does not support `HEAD`, use a
+   small idempotent `GET` instead. Finish probing when one usable candidate is
+   found or all four candidates have failed.
+
+3. Retry the original request through each usable candidate, stopping at the
+   first success. Prefer the client's per-command proxy flag. For example:
+
+   ```bash
+   curl --proxy "$proxy" <original curl arguments>
+   git -c http.proxy="$proxy" <original read-only git command>
+   ```
+
+   If a client only supports environment variables, scope them to that single
+   invocation. Use `HTTP_PROXY` and `HTTPS_PROXY` for an HTTP proxy, or
+   `ALL_PROXY=socks5h://127.0.0.1:<port>` for SOCKS5. Also set the lowercase
+   equivalent when the client requires it. Confirm that the client actually
+   honored the proxy. If the current network tool has no proxy support, use a
+   proxy-capable local client for an equivalent read-only fetch.
+
+4. Keep the fallback bounded. Never write proxy settings to shell profiles,
+   system settings, global Git config, or persistent package-manager config.
+   If every proxy attempt fails, report the direct error and the candidates
+   tested. If `403` remains after the proxy pass, treat it as an authentication
+   or access-policy result; stop rather than rotating identities or attempting
+   to bypass the restriction.

--- a/skills/retry-via-local-proxy/agents/openai.yaml
+++ b/skills/retry-via-local-proxy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Retry via Local Proxy"
+  short_description: "Retry failed fetches through local proxies"
+  default_prompt: "Use $retry-via-local-proxy to retry this failed read-only network fetch through a detected local proxy."


### PR DESCRIPTION
## Summary

- migrate the local-proxy retry workflow into the primary plugin
- add canonical Knowledge for GitHub Actions version selection and the Codex GitHub Copilot Enterprise provider
- require new Skills to discover and reuse existing Knowledge before adding duplicate guidance
- expand the human-facing README with installation, update, usage, contribution, and compatibility guidance

## Why

This moves the first reusable material into the centralized knowledge base and makes both Agent routing and human usage clearer. Knowledge remains canonical and independently reusable, while Skills provide task-facing discovery and execution behavior.

## Impact

Installed clients gain the migrated retry Skill and can discover the new Knowledge through the catalog. Skill authors are guided toward existing canonical Knowledge, and users now have documented installation, update, usage, and contribution paths for Codex and GitHub Copilot CLI.

## Validation

- `pnpm check`
- `pnpm exec remark "$(pwd)" --frail --quiet --use remark-validate-links`
- `git diff --check`
