### PR TITLE
[codex] automate PR-scoped knowledge-base versions

### DIFF
--- a/.agents/skills/add-to-knowledge-base/SKILL.md
+++ b/.agents/skills/add-to-knowledge-base/SKILL.md
@@ -29,12 +29,17 @@ Classify the material before choosing its destination.
    workflow.
 6. For mixed material, finish the Knowledge branch first so the Skill can
    reference the final canonical paths.
-7. Review the combined result and report the classification, changed paths,
-   and validation performed.
+7. When the final diff changes root `knowledge/**` or `skills/**`, follow
+   [`references/update-plugin-version.md`](references/update-plugin-version.md)
+   after the content stabilizes.
+8. Review the combined result and report the classification, changed paths,
+   generated primary-plugin version when applicable, and validation performed.
 
 ## Completion criteria
 
 Finish only when every part of the input has been classified, every accepted
 part has one authoritative home, the root Knowledge index and all references
 resolve, every user-facing part preserves downstream-project independence, and
-the resulting diff preserves the Knowledge-versus-Skill boundary.
+the resulting diff preserves the Knowledge-versus-Skill boundary. When root
+Knowledge or usage Skills changed, also require the PR-scoped primary-plugin
+version and its validation to be current.

--- a/.agents/skills/add-to-knowledge-base/references/update-plugin-version.md
+++ b/.agents/skills/add-to-knowledge-base/references/update-plugin-version.md
@@ -1,0 +1,28 @@
+# Update the primary plugin version
+
+Treat one pull request as one primary-plugin release. Changes within the pull
+request do not create additional releases.
+
+Apply this workflow when the final diff changes root `knowledge/**` or
+`skills/**`. Independent content under `plugins/**`, repository-authoring
+Skills under `.agents/**`, and repository documentation do not belong to the
+primary plugin version.
+
+1. Stabilize the pull request's intended content and integrate the latest PR
+   base before generating the version.
+2. Refresh the base ref, then run `pnpm plugin-version:update`. The command
+   reads `origin/main` by default; pass another base ref as its only argument
+   when the pull request targets a different ref.
+3. Treat the generated `plugin.json` version as the pull request's single
+   release version. Repeated runs against the same base on the same day are
+   idempotent.
+4. Rerun the command after rebasing, merging the base, resolving a conflict, or
+   crossing a calendar date before the final commit. CI derives the date from
+   the PR head commit's committer timestamp in `Asia/Shanghai`.
+5. Run the repository validation after the generated manifest is final.
+
+When `plugin.json` conflicts, first produce valid JSON that preserves the
+intended non-version fields from both sides. Treat either conflicting version
+as temporary, then run the update command and use its result. The sequence is
+derived from the current PR base, never from either side of the conflict or
+from the working tree's existing version.

--- a/.github/scripts/plugin-version/check.test.ts
+++ b/.github/scripts/plugin-version/check.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const checkerPath = fileURLToPath(new URL("./check.ts", import.meta.url));
+
+function git(
+  repository: string,
+  arguments_: string[],
+  env = process.env,
+): string {
+  return execFileSync("git", ["-C", repository, ...arguments_], {
+    encoding: "utf8",
+    env,
+  }).trim();
+}
+
+async function createRepository(
+  t: test.TestContext,
+  baseVersion: string,
+): Promise<string> {
+  const repository = await mkdtemp(join(tmpdir(), "plugin-version-check-"));
+  t.after(() => rm(repository, { force: true, recursive: true }));
+  git(repository, ["init", "--initial-branch=main"]);
+  git(repository, ["config", "user.name", "Plugin Version Test"]);
+  git(repository, ["config", "user.email", "plugin-version@example.com"]);
+  await writeFile(
+    join(repository, "plugin.json"),
+    `${JSON.stringify({ name: "knowledge-base", version: baseVersion }, null, 2)}\n`,
+  );
+  await mkdir(join(repository, "knowledge"));
+  await writeFile(join(repository, "knowledge", "index.md"), "# Index\n");
+  git(repository, ["add", "."]);
+  git(repository, ["commit", "-m", "base"]);
+  return repository;
+}
+
+function commit(
+  repository: string,
+  message: string,
+  authorDate: string,
+  committerDate: string,
+): string {
+  git(repository, ["add", "."]);
+  git(repository, ["commit", "-m", message], {
+    ...process.env,
+    GIT_AUTHOR_DATE: authorDate,
+    GIT_COMMITTER_DATE: committerDate,
+  });
+  return git(repository, ["rev-parse", "HEAD"]);
+}
+
+test("requires base and head revisions", () => {
+  const result = spawnSync(process.execPath, [checkerPath], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(
+    result.stderr,
+    "Usage: node check.ts <base-revision> <head-revision>\n",
+  );
+});
+
+test("uses the rebased head committer date instead of the author date", async (t) => {
+  const repository = await createRepository(t, "2026.8.15-1");
+  const base = git(repository, ["rev-parse", "HEAD"]);
+  await writeFile(
+    join(repository, "plugin.json"),
+    `${JSON.stringify({ name: "knowledge-base", version: "2026.8.18-1" }, null, 2)}\n`,
+  );
+  await writeFile(
+    join(repository, "knowledge", "index.md"),
+    "# Updated index\n",
+  );
+  const head = commit(
+    repository,
+    "update knowledge",
+    "2026-08-12T10:00:00+08:00",
+    "2026-08-18T10:00:00+08:00",
+  );
+
+  const result = spawnSync(process.execPath, [checkerPath, base, head], {
+    cwd: repository,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "Primary plugin version is 2026.8.18-1.\n");
+});
+
+test("requires a bump when root Knowledge changes", async (t) => {
+  const repository = await createRepository(t, "2026.8.15-1");
+  const base = git(repository, ["rev-parse", "HEAD"]);
+  await writeFile(
+    join(repository, "knowledge", "index.md"),
+    "# Updated index\n",
+  );
+  const head = commit(
+    repository,
+    "update knowledge",
+    "2026-08-15T10:00:00+08:00",
+    "2026-08-15T10:00:00+08:00",
+  );
+
+  const result = spawnSync(process.execPath, [checkerPath, base, head], {
+    cwd: repository,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /Expected primary plugin version '2026\.8\.15-2'/u,
+  );
+});
+
+test("does not version an independent plugin change", async (t) => {
+  const repository = await createRepository(t, "2026.8.15-1");
+  const base = git(repository, ["rev-parse", "HEAD"]);
+  const pluginDirectory = join(repository, "plugins", "example");
+  await mkdir(pluginDirectory, { recursive: true });
+  await writeFile(join(pluginDirectory, "plugin.json"), "{}\n");
+  const head = commit(
+    repository,
+    "update independent plugin",
+    "2026-08-15T10:00:00+08:00",
+    "2026-08-15T10:00:00+08:00",
+  );
+
+  const result = spawnSync(process.execPath, [checkerPath, base, head], {
+    cwd: repository,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /no versioned content changed/u);
+});
+
+test("rejects a version-only release after date versions are established", async (t) => {
+  const repository = await createRepository(t, "2026.8.15-1");
+  const base = git(repository, ["rev-parse", "HEAD"]);
+  await writeFile(
+    join(repository, "plugin.json"),
+    `${JSON.stringify({ name: "knowledge-base", version: "2026.8.15-2" }, null, 2)}\n`,
+  );
+  const head = commit(
+    repository,
+    "bump version only",
+    "2026-08-15T10:00:00+08:00",
+    "2026-08-15T10:00:00+08:00",
+  );
+
+  const result = spawnSync(process.execPath, [checkerPath, base, head], {
+    cwd: repository,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /version changed, but root Knowledge and usage Skills did not/u,
+  );
+});
+
+test("allows the one-time migration from a legacy version", async (t) => {
+  const repository = await createRepository(t, "0.1.0");
+  const base = git(repository, ["rev-parse", "HEAD"]);
+  await writeFile(
+    join(repository, "plugin.json"),
+    `${JSON.stringify({ name: "knowledge-base", version: "2026.8.15-1" }, null, 2)}\n`,
+  );
+  const head = commit(
+    repository,
+    "adopt date version",
+    "2026-08-15T10:00:00+08:00",
+    "2026-08-15T10:00:00+08:00",
+  );
+
+  const result = spawnSync(process.execPath, [checkerPath, base, head], {
+    cwd: repository,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "Primary plugin version is 2026.8.15-1.\n");
+});

--- a/.github/scripts/plugin-version/check.ts
+++ b/.github/scripts/plugin-version/check.ts
@@ -1,0 +1,127 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  listChangedFiles,
+  readCommitterTimestamp,
+  readFileAtRevision,
+} from "./repository.ts";
+import {
+  nextPluginVersion,
+  parsePluginVersion,
+  readManifestVersion,
+  releaseDateForTimestamp,
+} from "./version.ts";
+
+export interface CheckPluginVersionOptions {
+  repository: string;
+  baseRevision: string;
+  headRevision: string;
+}
+
+export interface CheckPluginVersionResult {
+  checked: boolean;
+  version: string;
+}
+
+function isVersionedContent(path: string): boolean {
+  return path.startsWith("knowledge/") || path.startsWith("skills/");
+}
+
+export function checkPluginVersion({
+  repository,
+  baseRevision,
+  headRevision,
+}: CheckPluginVersionOptions): CheckPluginVersionResult {
+  const baseContent = readFileAtRevision(
+    repository,
+    baseRevision,
+    "plugin.json",
+  );
+  const headContent = readFileAtRevision(
+    repository,
+    headRevision,
+    "plugin.json",
+  );
+  const baseVersion = readManifestVersion(
+    baseContent,
+    `plugin.json at ${baseRevision}`,
+  );
+  const headVersion = readManifestVersion(
+    headContent,
+    `plugin.json at ${headRevision}`,
+  );
+  const changedFiles = listChangedFiles(repository, baseRevision, headRevision);
+  const contentChanged = changedFiles.some(isVersionedContent);
+  const versionChanged = headVersion !== baseVersion;
+
+  if (!contentChanged && !versionChanged) {
+    return { checked: false, version: headVersion };
+  }
+
+  if (
+    !contentChanged &&
+    versionChanged &&
+    parsePluginVersion(baseVersion) !== undefined
+  ) {
+    throw new Error(
+      "The primary plugin version changed, but root Knowledge and usage Skills did not.",
+    );
+  }
+
+  const committerTimestamp = readCommitterTimestamp(repository, headRevision);
+  const releaseDate = releaseDateForTimestamp(committerTimestamp);
+  const expectedVersion = nextPluginVersion(baseVersion, releaseDate);
+
+  if (headVersion !== expectedVersion) {
+    const reason = contentChanged
+      ? "Versioned content changed."
+      : "The version field changed.";
+    throw new Error(
+      `${reason} Expected primary plugin version '${expectedVersion}' from base '${baseVersion}' and head committer timestamp '${committerTimestamp}', but found '${headVersion}'.`,
+    );
+  }
+
+  return { checked: true, version: headVersion };
+}
+
+function run(arguments_: string[]): number {
+  if (arguments_.length !== 2) {
+    process.stderr.write(
+      "Usage: node check.ts <base-revision> <head-revision>\n",
+    );
+    return 2;
+  }
+
+  const [baseRevision, headRevision] = arguments_;
+
+  if (baseRevision === undefined || headRevision === undefined) {
+    return 2;
+  }
+
+  try {
+    const result = checkPluginVersion({
+      repository: process.cwd(),
+      baseRevision,
+      headRevision,
+    });
+    const message = result.checked
+      ? `Primary plugin version is ${result.version}.`
+      : `Primary plugin version remains ${result.version}; no versioned content changed.`;
+    process.stdout.write(`${message}\n`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Plugin version check failed: ${message}\n`);
+    return 1;
+  }
+}
+
+const invokedPath = process.argv[1];
+
+if (
+  invokedPath !== undefined &&
+  resolve(invokedPath) === resolve(fileURLToPath(import.meta.url))
+) {
+  process.exitCode = run(process.argv.slice(2));
+}

--- a/.github/scripts/plugin-version/package.json
+++ b/.github/scripts/plugin-version/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@knowledge-base/plugin-version",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test *.test.ts",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/.github/scripts/plugin-version/repository.ts
+++ b/.github/scripts/plugin-version/repository.ts
@@ -1,0 +1,38 @@
+import { execFileSync } from "node:child_process";
+
+function git(repository: string, arguments_: string[]): string {
+  return execFileSync("git", ["-C", repository, ...arguments_], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+export function readFileAtRevision(
+  repository: string,
+  revision: string,
+  path: string,
+): string {
+  return git(repository, ["show", `${revision}:${path}`]);
+}
+
+export function readCommitterTimestamp(
+  repository: string,
+  revision: string,
+): string {
+  return git(repository, ["show", "-s", "--format=%cI", revision]).trim();
+}
+
+export function listChangedFiles(
+  repository: string,
+  baseRevision: string,
+  headRevision: string,
+): string[] {
+  const output = git(repository, [
+    "diff",
+    "--name-only",
+    "-z",
+    `${baseRevision}...${headRevision}`,
+    "--",
+  ]);
+  return output.split("\0").filter((path) => path.length > 0);
+}

--- a/.github/scripts/plugin-version/tsconfig.json
+++ b/.github/scripts/plugin-version/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["*.ts"]
+}

--- a/.github/scripts/plugin-version/update.test.ts
+++ b/.github/scripts/plugin-version/update.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { updatePluginVersion } from "./update.ts";
+
+function git(repository: string, arguments_: string[]): string {
+  return execFileSync("git", ["-C", repository, ...arguments_], {
+    encoding: "utf8",
+  }).trim();
+}
+
+test("repeated updates keep one version for the PR", async (t) => {
+  const repository = await mkdtemp(join(tmpdir(), "plugin-version-update-"));
+  t.after(() => rm(repository, { force: true, recursive: true }));
+  git(repository, ["init", "--initial-branch=main"]);
+  git(repository, ["config", "user.name", "Plugin Version Test"]);
+  git(repository, ["config", "user.email", "plugin-version@example.com"]);
+  await writeFile(
+    join(repository, "plugin.json"),
+    `${JSON.stringify({ name: "knowledge-base", version: "2026.8.15-1" }, null, 2)}\n`,
+  );
+  git(repository, ["add", "plugin.json"]);
+  git(repository, ["commit", "-m", "base"]);
+  const base = git(repository, ["rev-parse", "HEAD"]);
+
+  const options = {
+    repository,
+    baseRevision: base,
+    now: new Date("2026-08-15T10:00:00+08:00"),
+  };
+  assert.equal(await updatePluginVersion(options), "2026.8.15-2");
+  const afterFirstUpdate = await readFile(
+    join(repository, "plugin.json"),
+    "utf8",
+  );
+  assert.equal(await updatePluginVersion(options), "2026.8.15-2");
+  assert.equal(
+    await readFile(join(repository, "plugin.json"), "utf8"),
+    afterFirstUpdate,
+  );
+});

--- a/.github/scripts/plugin-version/update.ts
+++ b/.github/scripts/plugin-version/update.ts
@@ -1,0 +1,76 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { readFileAtRevision } from "./repository.ts";
+import {
+  nextPluginVersion,
+  readManifestVersion,
+  releaseDateForTimestamp,
+  replaceManifestVersion,
+} from "./version.ts";
+
+export interface UpdatePluginVersionOptions {
+  repository: string;
+  baseRevision: string;
+  now?: Date;
+}
+
+export async function updatePluginVersion({
+  repository,
+  baseRevision,
+  now = new Date(),
+}: UpdatePluginVersionOptions): Promise<string> {
+  const manifestPath = resolve(repository, "plugin.json");
+  const baseContent = readFileAtRevision(
+    repository,
+    baseRevision,
+    "plugin.json",
+  );
+  const currentContent = await readFile(manifestPath, "utf8");
+  const baseVersion = readManifestVersion(
+    baseContent,
+    `plugin.json at ${baseRevision}`,
+  );
+  const currentVersion = readManifestVersion(currentContent, "plugin.json");
+  const releaseDate = releaseDateForTimestamp(now);
+  const targetVersion = nextPluginVersion(baseVersion, releaseDate);
+
+  if (currentVersion !== targetVersion) {
+    await writeFile(
+      manifestPath,
+      replaceManifestVersion(currentContent, "plugin.json", targetVersion),
+    );
+  }
+
+  return targetVersion;
+}
+
+async function run(arguments_: string[]): Promise<number> {
+  if (arguments_.length > 1) {
+    process.stderr.write("Usage: node update.ts [base-revision]\n");
+    return 2;
+  }
+
+  const repository = fileURLToPath(new URL("../../../", import.meta.url));
+  const baseRevision = arguments_[0] ?? "origin/main";
+
+  try {
+    const version = await updatePluginVersion({ repository, baseRevision });
+    process.stdout.write(`Primary plugin version: ${version}\n`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Plugin version update failed: ${message}\n`);
+    return 1;
+  }
+}
+
+const invokedPath = process.argv[1];
+
+if (
+  invokedPath !== undefined &&
+  resolve(invokedPath) === resolve(fileURLToPath(import.meta.url))
+) {
+  process.exitCode = await run(process.argv.slice(2));
+}

--- a/.github/scripts/plugin-version/version.test.ts
+++ b/.github/scripts/plugin-version/version.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  nextPluginVersion,
+  parsePluginVersion,
+  releaseDateForTimestamp,
+} from "./version.ts";
+
+test("parses canonical plugin versions", () => {
+  assert.deepEqual(parsePluginVersion("2026.8.15-2"), {
+    date: "2026.8.15",
+    sequence: 2,
+  });
+});
+
+test("rejects noncanonical or impossible plugin versions", () => {
+  assert.equal(parsePluginVersion("2026.08.15-1"), undefined);
+  assert.equal(parsePluginVersion("2026.2.29-1"), undefined);
+  assert.equal(parsePluginVersion("2026.8.15-0"), undefined);
+});
+
+test("increments once from the PR base on the same day", () => {
+  assert.equal(nextPluginVersion("2026.8.15-3", "2026.8.15"), "2026.8.15-4");
+  assert.equal(nextPluginVersion("2026.8.15-3", "2026.8.15"), "2026.8.15-4");
+});
+
+test("starts at one for a later date or a legacy base version", () => {
+  assert.equal(nextPluginVersion("2026.8.15-3", "2026.8.18"), "2026.8.18-1");
+  assert.equal(nextPluginVersion("0.1.0", "2026.8.18"), "2026.8.18-1");
+});
+
+test("rejects a release date older than the base version", () => {
+  assert.throws(
+    () => nextPluginVersion("2026.8.15-3", "2026.8.12"),
+    /predates base version/u,
+  );
+});
+
+test("derives dates at the Asia/Shanghai boundary", () => {
+  assert.equal(
+    releaseDateForTimestamp("2026-08-14T15:59:59.000Z"),
+    "2026.8.14",
+  );
+  assert.equal(
+    releaseDateForTimestamp("2026-08-14T16:00:00.000Z"),
+    "2026.8.15",
+  );
+});

--- a/.github/scripts/plugin-version/version.ts
+++ b/.github/scripts/plugin-version/version.ts
@@ -1,0 +1,191 @@
+const versionPattern =
+  /^(?<year>\d{4})\.(?<month>[1-9]\d*)\.(?<day>[1-9]\d*)-(?<sequence>[1-9]\d*)$/u;
+const datePattern = /^(?<year>\d{4})\.(?<month>[1-9]\d*)\.(?<day>[1-9]\d*)$/u;
+
+export interface PluginVersion {
+  date: string;
+  sequence: number;
+}
+
+interface CalendarDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+function parseInteger(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function parseCalendarDate(value: string): CalendarDate | undefined {
+  const match = datePattern.exec(value);
+  const year = parseInteger(match?.groups?.year);
+  const month = parseInteger(match?.groups?.month);
+  const day = parseInteger(match?.groups?.day);
+
+  if (year === undefined || month === undefined || day === undefined) {
+    return undefined;
+  }
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return undefined;
+  }
+
+  return { year, month, day };
+}
+
+function compareCalendarDates(left: string, right: string): number {
+  const parsedLeft = parseCalendarDate(left);
+  const parsedRight = parseCalendarDate(right);
+
+  if (parsedLeft === undefined || parsedRight === undefined) {
+    throw new Error(
+      `Cannot compare invalid release dates '${left}' and '${right}'.`,
+    );
+  }
+
+  const leftValue = Date.UTC(
+    parsedLeft.year,
+    parsedLeft.month - 1,
+    parsedLeft.day,
+  );
+  const rightValue = Date.UTC(
+    parsedRight.year,
+    parsedRight.month - 1,
+    parsedRight.day,
+  );
+  return Math.sign(leftValue - rightValue);
+}
+
+export function parsePluginVersion(value: string): PluginVersion | undefined {
+  const match = versionPattern.exec(value);
+  const year = match?.groups?.year;
+  const month = match?.groups?.month;
+  const day = match?.groups?.day;
+  const sequence = parseInteger(match?.groups?.sequence);
+
+  if (
+    year === undefined ||
+    month === undefined ||
+    day === undefined ||
+    sequence === undefined
+  ) {
+    return undefined;
+  }
+
+  const date = `${year}.${month}.${day}`;
+  return parseCalendarDate(date) === undefined ? undefined : { date, sequence };
+}
+
+export function releaseDateForTimestamp(
+  timestamp: string | Date,
+  timeZone = "Asia/Shanghai",
+): string {
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid commit timestamp '${String(timestamp)}'.`);
+  }
+
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+  }).formatToParts(date);
+  const values = new Map(parts.map((part) => [part.type, part.value]));
+  const year = values.get("year");
+  const month = values.get("month");
+  const day = values.get("day");
+
+  if (year === undefined || month === undefined || day === undefined) {
+    throw new Error(`Cannot derive a release date in time zone '${timeZone}'.`);
+  }
+
+  return `${year}.${Number(month)}.${Number(day)}`;
+}
+
+export function nextPluginVersion(
+  baseVersion: string,
+  releaseDate: string,
+): string {
+  if (parseCalendarDate(releaseDate) === undefined) {
+    throw new Error(`Invalid release date '${releaseDate}'.`);
+  }
+
+  const parsedBase = parsePluginVersion(baseVersion);
+
+  if (parsedBase === undefined) {
+    return `${releaseDate}-1`;
+  }
+
+  const comparison = compareCalendarDates(releaseDate, parsedBase.date);
+
+  if (comparison < 0) {
+    throw new Error(
+      `Release date '${releaseDate}' predates base version '${baseVersion}'. Rebase onto the current PR base and regenerate the version.`,
+    );
+  }
+
+  const sequence = comparison === 0 ? parsedBase.sequence + 1 : 1;
+
+  if (!Number.isSafeInteger(sequence)) {
+    throw new Error(`Version sequence after '${baseVersion}' is too large.`);
+  }
+
+  return `${releaseDate}-${sequence}`;
+}
+
+export function readManifestVersion(content: string, source: string): string {
+  let manifest: unknown;
+
+  try {
+    manifest = JSON.parse(content);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Cannot parse ${source}: ${message}`, { cause: error });
+  }
+
+  if (
+    typeof manifest !== "object" ||
+    manifest === null ||
+    !("version" in manifest) ||
+    typeof manifest.version !== "string"
+  ) {
+    throw new Error(`${source} must contain a string 'version' field.`);
+  }
+
+  return manifest.version;
+}
+
+export function replaceManifestVersion(
+  content: string,
+  source: string,
+  version: string,
+): string {
+  let manifest: unknown;
+
+  try {
+    manifest = JSON.parse(content);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Cannot parse ${source}: ${message}`, { cause: error });
+  }
+
+  if (typeof manifest !== "object" || manifest === null) {
+    throw new Error(`${source} must contain a JSON object.`);
+  }
+
+  return `${JSON.stringify({ ...manifest, version }, null, 2)}\n`;
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,46 @@ jobs:
     name: Tooling
     uses: ./.github/workflows/tooling-checks.yml
 
+  plugin-version:
+    name: Plugin version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pull request head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up latest Node.js LTS
+        uses: actions/setup-node@v7
+        with:
+          node-version: "lts/*"
+          check-latest: true
+
+      - name: Check primary plugin version
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node .github/scripts/plugin-version/check.ts "$BASE_SHA" "$HEAD_SHA"
+
   required:
     name: CI
     if: ${{ always() }}
     needs:
       - plugin-install
+      - plugin-version
       - tooling
     runs-on: ubuntu-latest
     steps:
       - name: Verify required workflows succeeded
         env:
           PLUGIN_INSTALL_RESULT: ${{ needs.plugin-install.result }}
+          PLUGIN_VERSION_RESULT: ${{ needs.plugin-version.result }}
           TOOLING_RESULT: ${{ needs.tooling.result }}
         run: |
           printf 'Plugin installation: %s\n' "$PLUGIN_INSTALL_RESULT"
+          printf 'Plugin version: %s\n' "$PLUGIN_VERSION_RESULT"
           printf 'Tooling: %s\n' "$TOOLING_RESULT"
           test "$PLUGIN_INSTALL_RESULT" = success
+          test "$PLUGIN_VERSION_RESULT" = success
           test "$TOOLING_RESULT" = success

--- a/README.md
+++ b/README.md
@@ -24,12 +24,10 @@ codex plugin marketplace add Soulike/knowledge-base
 codex plugin add knowledge-base@knowledge-base
 ```
 
-To update an existing installation, refresh the marketplace snapshot and reinstall the plugin:
+To update an existing installation, refresh the marketplace snapshot:
 
 ```bash
 codex plugin marketplace upgrade knowledge-base
-codex plugin remove knowledge-base@knowledge-base
-codex plugin add knowledge-base@knowledge-base
 ```
 
 ## Install with GitHub Copilot CLI

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "knowledge:check": "node .github/scripts/check-knowledge-format/check.ts knowledge",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
+    "plugin-version:update": "node .github/scripts/plugin-version/update.ts",
     "prepare": "husky",
     "test": "pnpm --recursive --if-present test",
     "typecheck": "pnpm --recursive --if-present typecheck"

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "0.1.0",
+  "version": "2026.8.15-1",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,8 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4
 
+  .github/scripts/plugin-version: {}
+
   .github/scripts/smoke-plugin-install: {}
 
 packages:


### PR DESCRIPTION
## Summary

- simplify the Codex update instructions and adopt `2026.8.15-1` for the primary plugin
- add an idempotent updater that derives one release version from the PR base and the Asia/Shanghai date
- validate PR versions from the base SHA and head committer timestamp in CI
- document the PR-scoped workflow, including rebase, date rollover, and manifest conflict handling

## Why

The primary plugin version is intended to show when the installed Knowledge and usage Skills were released. Computing it from the PR base keeps repeated updates within one PR stable while still advancing after another PR merges.

## Impact

Changes under root `knowledge/**` or `skills/**` require one version update per PR. Independent plugins, repository-authoring Skills, and documentation do not advance the primary plugin version. The existing semantic version receives a one-time migration path to the date-based format.

## Validation

- `pnpm check`
- Skill structure validation with `quick_validate.py`
- internal Markdown link validation with `remark-validate-links`
- local update idempotence and PR-rule checks against `origin/main`
