### PR TITLE
[codex] Classify Knowledge by external-state sensitivity

### DIFF
--- a/.agents/skills/add-to-knowledge-base/SKILL.md
+++ b/.agents/skills/add-to-knowledge-base/SKILL.md
@@ -46,7 +46,8 @@ Classify the material before choosing its destination.
 Finish only when every part of the input has been classified, every accepted
 part has one authoritative home, the root Knowledge index and all references
 resolve, every user-facing part preserves downstream-project independence, and
-every Knowledge part has an independent installed-use reading responsibility.
-The resulting diff must preserve the Knowledge-versus-Skill boundary. When
-root Knowledge or usage Skills changed, also require the PR-scoped
-primary-plugin version and its validation to be current.
+every Knowledge part has an independent installed-use reading responsibility
+and a valid Knowledge Type. The resulting diff must preserve the
+Knowledge-versus-Skill boundary. When root Knowledge or usage Skills changed,
+also require the PR-scoped primary-plugin version and its validation to be
+current.

--- a/.agents/skills/add-to-knowledge-base/references/add-knowledge.md
+++ b/.agents/skills/add-to-knowledge-base/references/add-knowledge.md
@@ -27,12 +27,12 @@
    domain directories, but list every leaf directly in the root index and do
    not create nested `index.md` files.
 9. Add or update exactly one root-index row for every affected leaf document
-   using the fields below.
-10. Verify that every leaf document is listed exactly once, every changed
-    relative link resolves, and each concept has one canonical owner.
-    Compare every changed Scope and routing trigger with its pre-edit form;
-    keep additions that express the same responsibility and route independent
-    responsibilities separately.
+   using the fields below, including its Knowledge Type.
+10. Verify that every leaf document is listed exactly once with one valid
+    Knowledge Type, every changed relative link resolves, and each concept has
+    one canonical owner. Compare every changed Scope and routing trigger with
+    its pre-edit form; keep additions that express the same responsibility and
+    route independent responsibilities separately.
 11. Run `pnpm knowledge:check` from the repository root.
 
 ## Ownership and generalization
@@ -78,6 +78,25 @@ lists of editing steps.
 relative Markdown link from `knowledge/index.md` as its target. Point directly
 to a leaf Knowledge document, list it exactly once, and confirm that the target
 exists.
+
+**Knowledge Type.** Classify each leaf document as `time-sensitive` or
+`evergreen` according to the correctness of its substantive claims within its
+declared Scope:
+
+- **Time-sensitive Knowledge** depends on external state that is expected to
+  evolve, so changes outside the document can make its substantive claims no
+  longer correct. External state includes implementations, rules, policies,
+  standards, data, capabilities, environments, and professional consensus.
+- **Evergreen Knowledge** remains correct across ordinary changes to external
+  state within its declared Scope. It may still require revision when its
+  underlying principles, mechanisms, evidence, or Scope change.
+
+Ask: while the declared Scope stays fixed, could ordinary evolution of the
+external state make the document's substantive claims no longer correct even
+if the document itself does not change? Classify `time-sensitive` when the
+answer is yes and `evergreen` when the answer is no. Classify the claims the
+document makes, not the subject it discusses: a method for finding a current
+version can be evergreen even though version availability changes frequently.
 
 **When to Read.** Write a compact trigger beginning with `Read when` and name
 the concrete tasks, decisions, or artifacts that require this material. Cover

--- a/.github/scripts/check-knowledge-format/check.test.ts
+++ b/.github/scripts/check-knowledge-format/check.test.ts
@@ -19,6 +19,24 @@ This document defines the authentication guarantees shared by every client.
 Update this document when an authentication guarantee or supported client changes.
 `;
 
+function validIndex(rows: string): string {
+  return `# Knowledge index
+
+## Scope
+
+This index lists Knowledge.
+
+## When to update
+
+Update this index when Knowledge changes.
+
+## Documents
+
+| File Path | Knowledge Type | When to Read |
+| --- | --- | --- |
+${rows}`;
+}
+
 test("requires the knowledge directory as a CLI argument", () => {
   const result = spawnSync(process.execPath, [checkerPath], {
     encoding: "utf8",
@@ -37,7 +55,12 @@ test("recursively checks Markdown files through the CLI", async (t) => {
 
   await mkdir(nestedDirectory, { recursive: true });
   await Promise.all([
-    writeFile(join(knowledgeDirectory, "index.md"), validDocument),
+    writeFile(
+      join(knowledgeDirectory, "index.md"),
+      validIndex(
+        "| [knowledge/security/authentication.md](security/authentication.md) | evergreen | Read when authenticating. |\n",
+      ),
+    ),
     writeFile(join(nestedDirectory, "authentication.md"), validDocument),
     writeFile(join(nestedDirectory, "notes.txt"), "Not Markdown."),
   ]);
@@ -91,7 +114,7 @@ test("rejects nested knowledge indexes", async (t) => {
 
   await mkdir(nestedDirectory, { recursive: true });
   await Promise.all([
-    writeFile(join(knowledgeDirectory, "index.md"), validDocument),
+    writeFile(join(knowledgeDirectory, "index.md"), validIndex("")),
     writeFile(join(nestedDirectory, "index.md"), validDocument),
   ]);
 

--- a/.github/scripts/check-knowledge-format/check.ts
+++ b/.github/scripts/check-knowledge-format/check.ts
@@ -2,6 +2,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { basename, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { inspectKnowledgeIndex } from "./knowledge-index.ts";
 import { validateKnowledgeDocument } from "./validate.ts";
 
 export interface KnowledgeFormatDiagnostic {
@@ -43,15 +44,26 @@ export async function checkKnowledgeDirectory(
   const knowledgeDirectory = resolve(directory);
   const markdownFiles = await findMarkdownFiles(knowledgeDirectory);
   const diagnostics: KnowledgeFormatDiagnostic[] = [];
+  const relativeMarkdownFiles = markdownFiles.map((filePath) =>
+    toPortablePath(relative(knowledgeDirectory, filePath)),
+  );
+  let indexMarkdown: string | undefined;
 
-  for (const filePath of markdownFiles) {
+  for (const [index, filePath] of markdownFiles.entries()) {
     const markdown = await readFile(filePath, "utf8");
-    const relativeFilePath = toPortablePath(
-      relative(knowledgeDirectory, filePath),
-    );
+    const relativeFilePath = relativeMarkdownFiles[index];
+
+    if (relativeFilePath === undefined) {
+      continue;
+    }
+
     const displayPath = toPortablePath(
       join(basename(knowledgeDirectory), relativeFilePath),
     );
+
+    if (relativeFilePath === "index.md") {
+      indexMarkdown = markdown;
+    }
 
     if (
       relativeFilePath !== "index.md" &&
@@ -66,6 +78,26 @@ export async function checkKnowledgeDirectory(
 
     for (const message of validateKnowledgeDocument(markdown)) {
       diagnostics.push({ filePath: displayPath, message });
+    }
+  }
+
+  const indexDisplayPath = toPortablePath(
+    join(basename(knowledgeDirectory), "index.md"),
+  );
+
+  if (indexMarkdown === undefined) {
+    diagnostics.push({
+      filePath: indexDisplayPath,
+      message: "The root Knowledge index is required.",
+    });
+  } else {
+    const leafFilePaths = relativeMarkdownFiles.filter(
+      (filePath) => filePath !== "index.md" && !filePath.endsWith("/index.md"),
+    );
+    const inspection = inspectKnowledgeIndex(indexMarkdown, leafFilePaths);
+
+    for (const message of inspection.diagnostics) {
+      diagnostics.push({ filePath: indexDisplayPath, message });
     }
   }
 

--- a/.github/scripts/check-knowledge-format/knowledge-index.test.ts
+++ b/.github/scripts/check-knowledge-format/knowledge-index.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { inspectKnowledgeIndex } from "./knowledge-index.ts";
+
+function indexWithRows(rows: string): string {
+  return `# Knowledge index
+
+## Scope
+
+This index lists Knowledge.
+
+## When to update
+
+Update this index when Knowledge changes.
+
+## Documents
+
+| File Path | Knowledge Type | When to Read |
+| --- | --- | --- |
+${rows}`;
+}
+
+test("accepts an exhaustive Knowledge Type partition", () => {
+  const markdown =
+    indexWithRows(`| [knowledge/agents/model.md](agents/model.md) | evergreen | Read when modeling Agents. |
+| [knowledge/provider/config.md](provider/config.md) | time-sensitive | Read when configuring a provider. |
+`);
+
+  assert.deepEqual(
+    inspectKnowledgeIndex(markdown, ["agents/model.md", "provider/config.md"]),
+    {
+      entries: [
+        {
+          filePath: "agents/model.md",
+          knowledgeType: "evergreen",
+          whenToRead: "Read when modeling Agents.",
+        },
+        {
+          filePath: "provider/config.md",
+          knowledgeType: "time-sensitive",
+          whenToRead: "Read when configuring a provider.",
+        },
+      ],
+      diagnostics: [],
+    },
+  );
+});
+
+test("rejects an unknown Knowledge Type", () => {
+  const markdown = indexWithRows(
+    "| [knowledge/agents/model.md](agents/model.md) | static | Read when modeling Agents. |\n",
+  );
+
+  assert.deepEqual(inspectKnowledgeIndex(markdown, ["agents/model.md"]), {
+    entries: [],
+    diagnostics: [
+      "Knowledge Type for 'knowledge/agents/model.md' must be 'time-sensitive' or 'evergreen'.",
+    ],
+  });
+});
+
+test("rejects missing, duplicate, and nonexistent index entries", () => {
+  const markdown =
+    indexWithRows(`| [knowledge/agents/model.md](agents/model.md) | evergreen | Read when modeling Agents. |
+| [knowledge/agents/model.md](agents/model.md) | evergreen | Read when modeling Agents. |
+| [knowledge/missing.md](missing.md) | time-sensitive | Read when reading missing Knowledge. |
+`);
+
+  assert.deepEqual(
+    inspectKnowledgeIndex(markdown, ["agents/model.md", "security/auth.md"])
+      .diagnostics,
+    [
+      "Knowledge document 'knowledge/agents/model.md' must be listed exactly once, but it appears 2 times.",
+      "The index lists 'knowledge/missing.md', but that leaf document does not exist.",
+      "Knowledge leaf 'knowledge/security/auth.md' must be listed exactly once in the index.",
+    ],
+  );
+});
+
+test("requires the canonical Documents table columns", () => {
+  const markdown = indexWithRows("").replace(
+    "| File Path | Knowledge Type | When to Read |\n| --- | --- | --- |",
+    "| File Path | When to Read |\n| --- | --- |",
+  );
+
+  assert.deepEqual(inspectKnowledgeIndex(markdown, []).diagnostics, [
+    "The Documents table must have the columns 'File Path', 'Knowledge Type', and 'When to Read' in that order.",
+  ]);
+});

--- a/.github/scripts/check-knowledge-format/knowledge-index.ts
+++ b/.github/scripts/check-knowledge-format/knowledge-index.ts
@@ -1,0 +1,191 @@
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { gfmTableFromMarkdown } from "mdast-util-gfm-table";
+import { toString } from "mdast-util-to-string";
+import { gfmTable } from "micromark-extension-gfm-table";
+import type { Heading, Link, RootContent, Table, TableCell } from "mdast";
+
+const expectedColumns = ["File Path", "Knowledge Type", "When to Read"];
+const knowledgeTypes = ["time-sensitive", "evergreen"] as const;
+
+export type KnowledgeType = (typeof knowledgeTypes)[number];
+
+export interface KnowledgeIndexEntry {
+  filePath: string;
+  knowledgeType: KnowledgeType;
+  whenToRead: string;
+}
+
+export interface KnowledgeIndexInspection {
+  entries: KnowledgeIndexEntry[];
+  diagnostics: string[];
+}
+
+function isHeading(
+  node: RootContent | undefined,
+  depth: Heading["depth"],
+  value: string,
+): node is Heading {
+  return (
+    node?.type === "heading" && node.depth === depth && toString(node) === value
+  );
+}
+
+function isTable(node: RootContent | undefined): node is Table {
+  return node?.type === "table";
+}
+
+function onlyLink(cell: TableCell | undefined): Link | undefined {
+  if (cell?.children.length !== 1) {
+    return undefined;
+  }
+
+  const child = cell.children[0];
+  return child?.type === "link" ? child : undefined;
+}
+
+function isKnowledgeType(value: string): value is KnowledgeType {
+  return knowledgeTypes.some((knowledgeType) => knowledgeType === value);
+}
+
+export function inspectKnowledgeIndex(
+  markdown: string,
+  leafFilePaths: string[],
+): KnowledgeIndexInspection {
+  const document = fromMarkdown(markdown, {
+    extensions: [gfmTable()],
+    mdastExtensions: [gfmTableFromMarkdown()],
+  });
+  const documentsHeadingIndex = document.children.findIndex((node) =>
+    isHeading(node, 2, "Documents"),
+  );
+  const diagnostics: string[] = [];
+  const entries: KnowledgeIndexEntry[] = [];
+
+  if (documentsHeadingIndex === -1) {
+    return {
+      entries,
+      diagnostics: ["The index must contain a '## Documents' section."],
+    };
+  }
+
+  const table = document.children[documentsHeadingIndex + 1];
+
+  if (!isTable(table)) {
+    return {
+      entries,
+      diagnostics: [
+        "The Documents section must contain a GFM table immediately after its heading.",
+      ],
+    };
+  }
+
+  const header = table.children[0];
+  const headerCells = header?.children.map((cell) => toString(cell));
+
+  if (
+    headerCells === undefined ||
+    headerCells.length !== expectedColumns.length ||
+    headerCells.some((column, index) => column !== expectedColumns[index])
+  ) {
+    return {
+      entries,
+      diagnostics: [
+        "The Documents table must have the columns 'File Path', 'Knowledge Type', and 'When to Read' in that order.",
+      ],
+    };
+  }
+
+  const indexedPathCounts = new Map<string, number>();
+
+  for (const row of table.children.slice(1)) {
+    const cells = row.children;
+    const lineNumber = row.position?.start.line;
+    const location =
+      lineNumber === undefined
+        ? "A Documents table row"
+        : `Documents table line ${lineNumber}`;
+
+    if (cells.length !== expectedColumns.length) {
+      diagnostics.push(`${location} must contain exactly three columns.`);
+      continue;
+    }
+
+    const [filePathCell, knowledgeTypeCell, whenToReadCell] = cells;
+    const filePathLink = onlyLink(filePathCell);
+
+    if (filePathLink === undefined) {
+      diagnostics.push(
+        `${location} must link a repository-root-relative 'knowledge/...' path to its knowledge-relative target.`,
+      );
+      continue;
+    }
+
+    const targetPath = filePathLink.url;
+
+    if (toString(filePathLink) !== `knowledge/${targetPath}`) {
+      diagnostics.push(
+        `${location} link text and target must identify the same Knowledge document.`,
+      );
+    }
+
+    if (
+      targetPath.length === 0 ||
+      targetPath.startsWith("/") ||
+      targetPath
+        .split("/")
+        .some((segment) => segment === "." || segment === "..") ||
+      !targetPath.endsWith(".md")
+    ) {
+      diagnostics.push(
+        `${location} must target a knowledge-relative Markdown leaf path.`,
+      );
+      continue;
+    }
+
+    indexedPathCounts.set(
+      targetPath,
+      (indexedPathCounts.get(targetPath) ?? 0) + 1,
+    );
+
+    const knowledgeType = toString(knowledgeTypeCell);
+
+    if (!isKnowledgeType(knowledgeType)) {
+      diagnostics.push(
+        `Knowledge Type for 'knowledge/${targetPath}' must be 'time-sensitive' or 'evergreen'.`,
+      );
+      continue;
+    }
+
+    entries.push({
+      filePath: targetPath,
+      knowledgeType,
+      whenToRead: toString(whenToReadCell),
+    });
+  }
+
+  const leafPathSet = new Set(leafFilePaths);
+
+  for (const [filePath, count] of indexedPathCounts) {
+    if (count > 1) {
+      diagnostics.push(
+        `Knowledge document 'knowledge/${filePath}' must be listed exactly once, but it appears ${count} times.`,
+      );
+    }
+
+    if (!leafPathSet.has(filePath)) {
+      diagnostics.push(
+        `The index lists 'knowledge/${filePath}', but that leaf document does not exist.`,
+      );
+    }
+  }
+
+  for (const leafFilePath of leafFilePaths) {
+    if (!indexedPathCounts.has(leafFilePath)) {
+      diagnostics.push(
+        `Knowledge leaf 'knowledge/${leafFilePath}' must be listed exactly once in the index.`,
+      );
+    }
+  }
+
+  return { entries, diagnostics };
+}

--- a/.github/scripts/check-knowledge-format/package.json
+++ b/.github/scripts/check-knowledge-format/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "mdast-util-from-markdown": "^2.0.3",
-    "mdast-util-to-string": "^4.0.0"
+    "mdast-util-gfm-table": "^2.0.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-extension-gfm-table": "^2.1.1"
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,13 @@ project; otherwise leave it in the source project. Repository-authoring Skills
 are outside this user-facing boundary; the narrow contribution exception is
 described below.
 
+## Markdown tests
+
+Tests that inspect Markdown documents must use the repository's existing
+Markdown parser and assert against the parsed structure. Treat Markdown source
+text only as parser input; do not infer Markdown structure by matching,
+splitting, or replacing raw text.
+
 ## Skill scopes
 
 Choose a Skill's location by its audience and lifecycle, not by its subject.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,13 @@
 The repository root is the primary `knowledge-base` plugin. In this repository,
 **knowledge base** means the complete repository and plugin, **Knowledge** means
 the static content under `knowledge/`, and **Skill** means an Agent workflow.
+Here, static distinguishes content that provides understanding from a workflow
+that controls execution; it does not mean that the content cannot become stale.
 
 - `knowledge/` contains canonical, static knowledge organized by domain. Keep
   `knowledge/index.md` as the only index and list every leaf Knowledge document
-  there directly. Use subdirectories for organization, not nested indexes.
+  there directly with its `time-sensitive` or `evergreen` Knowledge Type. Use
+  subdirectories for organization, not nested indexes.
 - `.agents/skills/` contains workflows used while authoring and maintaining
   this repository.
 - `skills/` contains workflows used after installing the primary plugin.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -2,18 +2,18 @@
 
 ## Scope
 
-This index is the only routing catalog for Knowledge stored in the primary `knowledge-base` plugin and lists every leaf document directly; subdirectories organize files by domain, while detailed subject matter belongs in the linked documents rather than here.
+This index is the only routing catalog for Knowledge stored in the primary `knowledge-base` plugin and lists every leaf document directly with its Knowledge Type and reading trigger; subdirectories organize files by domain, while detailed subject matter belongs in the linked documents rather than here.
 
 ## When to update
 
-Update this index when a leaf Knowledge document is added, removed, renamed, or assigned a different canonical responsibility or `When to Read` condition.
+Update this index when a leaf Knowledge document is added, removed, renamed, or assigned a different canonical responsibility, Knowledge Type, or `When to Read` condition.
 
 ## Documents
 
-| File Path                                                                                                  | When to Read                                                                                                                                                                          |
-| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [knowledge/agents/knowledge-and-skills.md](agents/knowledge-and-skills.md)                                 | Read when deciding whether reusable Agent material should be represented as Knowledge, a Skill, or a split of both.                                                                   |
-| [knowledge/codex/github-copilot-enterprise-provider.md](codex/github-copilot-enterprise-provider.md)       | Read when configuring or troubleshooting Codex to use a GitHub Copilot Enterprise subscription as a custom model provider.                                                            |
-| [knowledge/filesystems/pathnames-and-resource-identity.md](filesystems/pathnames-and-resource-identity.md) | Read when designing or reviewing a multi-step filesystem operation whose pathname may be rebound between validation, use, mutation, placement, cleanup, or rollback.                  |
-| [knowledge/github-actions/version-selection.md](github-actions/version-selection.md)                       | Read when creating, editing, or reviewing a GitHub Actions workflow that declares a third-party action, runtime, or tool version.                                                     |
-| [knowledge/nodejs/filesystem-identity-primitives.md](nodejs/filesystem-identity-primitives.md)             | Read when implementing filesystem identity safeguards with Node.js `node:fs`, including `FileHandle` use, open flags, resource ownership, error handling, or parent-directory limits. |
+| File Path                                                                                                  | Knowledge Type | When to Read                                                                                                                                                                          |
+| ---------------------------------------------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [knowledge/agents/knowledge-and-skills.md](agents/knowledge-and-skills.md)                                 | evergreen      | Read when deciding whether reusable Agent material should be represented as Knowledge, a Skill, or a split of both.                                                                   |
+| [knowledge/codex/github-copilot-enterprise-provider.md](codex/github-copilot-enterprise-provider.md)       | time-sensitive | Read when configuring or troubleshooting Codex to use a GitHub Copilot Enterprise subscription as a custom model provider.                                                            |
+| [knowledge/filesystems/pathnames-and-resource-identity.md](filesystems/pathnames-and-resource-identity.md) | evergreen      | Read when designing or reviewing a multi-step filesystem operation whose pathname may be rebound between validation, use, mutation, placement, cleanup, or rollback.                  |
+| [knowledge/github-actions/version-selection.md](github-actions/version-selection.md)                       | evergreen      | Read when creating, editing, or reviewing a GitHub Actions workflow that declares a third-party action, runtime, or tool version.                                                     |
+| [knowledge/nodejs/filesystem-identity-primitives.md](nodejs/filesystem-identity-primitives.md)             | time-sensitive | Read when implementing filesystem identity safeguards with Node.js `node:fs`, including `FileHandle` use, open flags, resource ownership, error handling, or parent-directory limits. |

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.16-2",
+  "version": "2026.8.16-3",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,9 +43,15 @@ importers:
       mdast-util-from-markdown:
         specifier: ^2.0.3
         version: 2.0.3(supports-color@9.0.0)
+      mdast-util-gfm-table:
+        specifier: ^2.0.0
+        version: 2.0.0(supports-color@9.0.0)
       mdast-util-to-string:
         specifier: ^4.0.0
         version: 4.0.0
+      micromark-extension-gfm-table:
+        specifier: ^2.1.1
+        version: 2.1.1
     devDependencies:
       "@types/mdast":
         specifier: ^4.0.4
@@ -1085,10 +1091,22 @@ packages:
       }
     engines: { node: ">=16" }
 
+  markdown-table@3.0.4:
+    resolution:
+      {
+        integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==,
+      }
+
   mdast-util-from-markdown@2.0.3:
     resolution:
       {
         integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==,
+      }
+
+  mdast-util-gfm-table@2.0.0:
+    resolution:
+      {
+        integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==,
       }
 
   mdast-util-phrasing@4.1.0:
@@ -1119,6 +1137,12 @@ packages:
     resolution:
       {
         integrity: sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==,
+      }
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution:
+      {
+        integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==,
       }
 
   micromark-factory-destination@2.0.0:
@@ -2448,6 +2472,8 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  markdown-table@3.0.4: {}
+
   mdast-util-from-markdown@2.0.3(supports-color@9.0.0):
     dependencies:
       "@types/mdast": 4.0.4
@@ -2462,6 +2488,16 @@ snapshots:
       micromark-util-symbol: 2.0.0
       micromark-util-types: 2.0.0
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0(supports-color@9.0.0):
+    dependencies:
+      "@types/mdast": 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3(supports-color@9.0.0)
+      mdast-util-to-markdown: 2.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2513,6 +2549,14 @@ snapshots:
       micromark-util-normalize-identifier: 2.0.0
       micromark-util-resolve-all: 2.0.0
       micromark-util-subtokenize: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.0.0
       micromark-util-symbol: 2.0.0
       micromark-util-types: 2.0.0
 


### PR DESCRIPTION
## Summary

- add `time-sensitive` and `evergreen` Knowledge Types to the root catalog and classify every leaf document
- define classification by whether ordinary changes in external state can invalidate substantive claims within a fixed Scope
- validate the catalog through the existing mdast/GFM parsing stack, including type values, links, paths, uniqueness, and complete leaf coverage
- document that Markdown tests must assert against parsed structure instead of inferring structure from raw text
- update the primary plugin version to `2026.8.16-3`

## Why

Knowledge review cadence should be derived from the nature of the Knowledge rather than used as its classification. Recording that nature in the existing catalog allows future scheduled workflows to review different categories at different intervals without reorganizing the domain-based directory structure.

The parser-backed validation keeps the catalog exhaustive and prevents its classification metadata from drifting away from the Knowledge tree.

## Impact

Every Knowledge leaf now has one explicit Knowledge Type. Repository authors receive a precise classification test and a Markdown-testing convention. This PR intentionally does not add scheduled review workflows or select their cadence.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm plugin-version:update` (stable at `2026.8.16-3`)
- `pnpm check`
- `pnpm exec remark "$PWD" --frail --quiet --use remark-validate-links`
- `git diff --check`
