### PR TITLE
Document Copilot CLI request headers

### DIFF
--- a/knowledge/codex/github-copilot-enterprise-provider.md
+++ b/knowledge/codex/github-copilot-enterprise-provider.md
@@ -2,11 +2,11 @@
 
 ## Scope
 
-This document records a verified Codex custom-provider configuration for using models made available through a GitHub Copilot Enterprise subscription. It covers the provider endpoint and protocol, command-backed GitHub authentication, model selection boundaries, secret handling, and failure classification; GitHub enterprise provisioning, model recommendations, and unrelated transport, retry, timeout, or WebSocket tuning are outside its scope.
+This document records a verified Codex custom-provider configuration for using models made available through a GitHub Copilot Enterprise subscription. It covers the provider endpoint and protocol, optional Copilot CLI request identification, command-backed GitHub authentication, model selection boundaries, secret handling, and failure classification; GitHub enterprise provisioning, model recommendations, and unrelated transport, retry, timeout, or WebSocket tuning are outside its scope.
 
 ## When to update
 
-Update this document when Codex changes its custom-provider or command-backed authentication schema, GitHub changes the Copilot Enterprise endpoint or its Responses API compatibility, the GitHub CLI changes how credentials are obtained, or observed model discovery, access, or error behavior no longer matches the guidance here.
+Update this document when Codex changes its custom-provider or command-backed authentication schema, GitHub changes the Copilot Enterprise endpoint, its Responses API compatibility, or the Copilot CLI integration headers, the GitHub CLI changes how credentials are obtained, or observed model discovery, access, or error behavior no longer matches the guidance here.
 
 ## Preconditions
 
@@ -33,6 +33,20 @@ args = ["auth", "token", "-h", "github.com"]
 ```
 
 The top-level `model_provider` selects the custom provider. `wire_api = "responses"` makes Codex use the Responses protocol expected by this endpoint. The nested `auth` table makes Codex obtain the credential from the GitHub CLI instead of storing a token in the configuration file.
+
+## Identify requests as Copilot CLI
+
+To identify requests sent through this provider as Copilot CLI, add `http_headers` to the existing provider table:
+
+```toml
+[model_providers.github-copilot-enterprise]
+name = "GitHub Copilot Enterprise"
+base_url = "https://api.enterprise.githubcopilot.com"
+wire_api = "responses"
+http_headers = { "Copilot-Integration-Id" = "copilot-developer-cli", "Editor-Version" = "CopilotCLI/1.0" }
+```
+
+Use this block in place of the provider block in the main example rather than declaring `[model_providers.github-copilot-enterprise]` twice. These headers identify the integration but do not authenticate the request or change entitlement, model availability, endpoint, or protocol requirements; keep the command-backed `auth` table and the other provider settings unchanged. Omit `http_headers` when Copilot CLI identification is not intended.
 
 ## Select a model from current availability
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.16-4",
+  "version": "2026.8.16-5",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }


### PR DESCRIPTION
## Summary

- document the optional headers that identify Codex provider requests as Copilot CLI
- clarify that request identification does not replace authentication or provider settings
- bump the primary knowledge-base plugin version to 2026.8.16-5

## Validation

- Not run because dependency installation is currently unavailable; skipped as requested.