### PR TITLE
[codex] delay pnpm dependency installation by 14 days

### DIFF
--- a/.github/workflows/tooling-checks.yml
+++ b/.github/workflows/tooling-checks.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: latest
 
       - name: Set up latest Node.js LTS
         uses: actions/setup-node@v7

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "knowledge-base",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.21.0",
   "engines": {
     "node": ">=24"
   },
@@ -28,13 +27,13 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^24.13.3",
-    "eslint": "^10.8.1",
+    "eslint": "^10.8.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.3.0",
     "prettier": "^3.9.6",
     "remark-cli": "^12.0.1",
     "remark-validate-links": "^13.1.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.67.0"
+    "typescript-eslint": "^8.65.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,13 +9,13 @@ importers:
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.8.1(supports-color@9.0.0))
+        version: 10.0.1(eslint@10.8.0(supports-color@9.0.0))
       "@types/node":
         specifier: ^24.13.3
         version: 24.13.3
       eslint:
-        specifier: ^10.8.1
-        version: 10.8.1(supports-color@9.0.0)
+        specifier: ^10.8.0
+        version: 10.8.0(supports-color@9.0.0)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -35,8 +35,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       typescript-eslint:
-        specifier: ^8.67.0
-        version: 8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
+        specifier: ^8.65.0
+        version: 8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
 
   .github/scripts/check-knowledge-format:
     dependencies:
@@ -298,92 +298,92 @@ packages:
         integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==,
       }
 
-  "@typescript-eslint/eslint-plugin@8.67.0":
+  "@typescript-eslint/eslint-plugin@8.65.0":
     resolution:
       {
-        integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==,
+        integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      "@typescript-eslint/parser": ^8.67.0
+      "@typescript-eslint/parser": ^8.65.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/parser@8.67.0":
+  "@typescript-eslint/parser@8.65.0":
     resolution:
       {
-        integrity: sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/project-service@8.67.0":
-    resolution:
-      {
-        integrity: sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/scope-manager@8.67.0":
-    resolution:
-      {
-        integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/tsconfig-utils@8.67.0":
-    resolution:
-      {
-        integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/type-utils@8.67.0":
-    resolution:
-      {
-        integrity: sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==,
+        integrity: sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/types@8.67.0":
+  "@typescript-eslint/project-service@8.65.0":
     resolution:
       {
-        integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/typescript-estree@8.67.0":
-    resolution:
-      {
-        integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==,
+        integrity: sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/utils@8.67.0":
+  "@typescript-eslint/scope-manager@8.65.0":
     resolution:
       {
-        integrity: sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==,
+        integrity: sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/tsconfig-utils@8.65.0":
+    resolution:
+      {
+        integrity: sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/type-utils@8.65.0":
+    resolution:
+      {
+        integrity: sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/visitor-keys@8.67.0":
+  "@typescript-eslint/types@8.65.0":
     resolution:
       {
-        integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==,
+        integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/typescript-estree@8.65.0":
+    resolution:
+      {
+        integrity: sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/utils@8.65.0":
+    resolution:
+      {
+        integrity: sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/visitor-keys@8.65.0":
+    resolution:
+      {
+        integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
@@ -428,10 +428,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  ansi-regex@6.3.0:
+  ansi-regex@6.2.2:
     resolution:
       {
-        integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==,
+        integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
       }
     engines: { node: ">=12" }
 
@@ -668,10 +668,10 @@ packages:
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-  eslint@10.8.1:
+  eslint@10.8.0:
     resolution:
       {
-        integrity: sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==,
+        integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==,
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
     hasBin: true
@@ -857,6 +857,14 @@ packages:
       }
     engines: { node: ">=18" }
     hasBin: true
+
+  ignore@5.0.0:
+    resolution:
+      {
+        integrity: sha512-pztwzOo3khA5uk+1N6erjer98k1hBPsCA3EYoCBYEjeRKo1lYUEwLfOhnHuHE9ahHepH2o+Fc3KtUzQbmKTHAA==,
+      }
+    engines: { node: ">= 4" }
+    deprecated: due to failure of importing in typescript
 
   ignore@5.2.0:
     resolution:
@@ -1076,6 +1084,13 @@ packages:
       {
         integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
       }
+
+  lru-cache@10.0.1:
+    resolution:
+      {
+        integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==,
+      }
+    engines: { node: 14 || >=16.14 }
 
   lru-cache@10.2.0:
     resolution:
@@ -1700,10 +1715,10 @@ packages:
         integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==,
       }
 
-  typescript-eslint@8.67.0:
+  typescript-eslint@8.65.0:
     resolution:
       {
-        integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==,
+        integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
@@ -1890,9 +1905,9 @@ snapshots:
 
   "@babel/helper-validator-identifier@7.29.7": {}
 
-  "@eslint-community/eslint-utils@4.10.1(eslint@10.8.1(supports-color@9.0.0))":
+  "@eslint-community/eslint-utils@4.10.1(eslint@10.8.0(supports-color@9.0.0))":
     dependencies:
-      eslint: 10.8.1(supports-color@9.0.0)
+      eslint: 10.8.0(supports-color@9.0.0)
       eslint-visitor-keys: 3.4.3
 
   "@eslint-community/regexpp@4.12.2": {}
@@ -1913,9 +1928,9 @@ snapshots:
     dependencies:
       "@types/json-schema": 7.0.15
 
-  "@eslint/js@10.0.1(eslint@10.8.1(supports-color@9.0.0))":
+  "@eslint/js@10.0.1(eslint@10.8.0(supports-color@9.0.0))":
     optionalDependencies:
-      eslint: 10.8.1(supports-color@9.0.0)
+      eslint: 10.8.0(supports-color@9.0.0)
 
   "@eslint/object-schema@3.0.5": {}
 
@@ -2013,15 +2028,15 @@ snapshots:
 
   "@types/unist@3.0.3": {}
 
-  "@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3))(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)":
+  "@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3))(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)":
     dependencies:
       "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
-      "@typescript-eslint/scope-manager": 8.67.0
-      "@typescript-eslint/type-utils": 8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
-      "@typescript-eslint/visitor-keys": 8.67.0
-      eslint: 10.8.1(supports-color@9.0.0)
+      "@typescript-eslint/parser": 8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
+      "@typescript-eslint/scope-manager": 8.65.0
+      "@typescript-eslint/type-utils": 8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
+      "@typescript-eslint/utils": 8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
+      "@typescript-eslint/visitor-keys": 8.65.0
+      eslint: 10.8.0(supports-color@9.0.0)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -2029,56 +2044,56 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)":
+  "@typescript-eslint/parser@8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/scope-manager": 8.67.0
-      "@typescript-eslint/types": 8.67.0
-      "@typescript-eslint/typescript-estree": 8.67.0(supports-color@9.0.0)(typescript@6.0.3)
-      "@typescript-eslint/visitor-keys": 8.67.0
+      "@typescript-eslint/scope-manager": 8.65.0
+      "@typescript-eslint/types": 8.65.0
+      "@typescript-eslint/typescript-estree": 8.65.0(supports-color@9.0.0)(typescript@6.0.3)
+      "@typescript-eslint/visitor-keys": 8.65.0
       debug: 4.4.3(supports-color@9.0.0)
-      eslint: 10.8.1(supports-color@9.0.0)
+      eslint: 10.8.0(supports-color@9.0.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/project-service@8.67.0(supports-color@9.0.0)(typescript@6.0.3)":
+  "@typescript-eslint/project-service@8.65.0(supports-color@9.0.0)(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.67.0(typescript@6.0.3)
-      "@typescript-eslint/types": 8.67.0
+      "@typescript-eslint/tsconfig-utils": 8.65.0(typescript@6.0.3)
+      "@typescript-eslint/types": 8.65.0
       debug: 4.4.3(supports-color@9.0.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/scope-manager@8.67.0":
+  "@typescript-eslint/scope-manager@8.65.0":
     dependencies:
-      "@typescript-eslint/types": 8.67.0
-      "@typescript-eslint/visitor-keys": 8.67.0
+      "@typescript-eslint/types": 8.65.0
+      "@typescript-eslint/visitor-keys": 8.65.0
 
-  "@typescript-eslint/tsconfig-utils@8.67.0(typescript@6.0.3)":
+  "@typescript-eslint/tsconfig-utils@8.65.0(typescript@6.0.3)":
     dependencies:
       typescript: 6.0.3
 
-  "@typescript-eslint/type-utils@8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)":
+  "@typescript-eslint/type-utils@8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/types": 8.67.0
-      "@typescript-eslint/typescript-estree": 8.67.0(supports-color@9.0.0)(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
+      "@typescript-eslint/types": 8.65.0
+      "@typescript-eslint/typescript-estree": 8.65.0(supports-color@9.0.0)(typescript@6.0.3)
+      "@typescript-eslint/utils": 8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
       debug: 4.4.3(supports-color@9.0.0)
-      eslint: 10.8.1(supports-color@9.0.0)
+      eslint: 10.8.0(supports-color@9.0.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/types@8.67.0": {}
+  "@typescript-eslint/types@8.65.0": {}
 
-  "@typescript-eslint/typescript-estree@8.67.0(supports-color@9.0.0)(typescript@6.0.3)":
+  "@typescript-eslint/typescript-estree@8.65.0(supports-color@9.0.0)(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/project-service": 8.67.0(supports-color@9.0.0)(typescript@6.0.3)
-      "@typescript-eslint/tsconfig-utils": 8.67.0(typescript@6.0.3)
-      "@typescript-eslint/types": 8.67.0
-      "@typescript-eslint/visitor-keys": 8.67.0
+      "@typescript-eslint/project-service": 8.65.0(supports-color@9.0.0)(typescript@6.0.3)
+      "@typescript-eslint/tsconfig-utils": 8.65.0(typescript@6.0.3)
+      "@typescript-eslint/types": 8.65.0
+      "@typescript-eslint/visitor-keys": 8.65.0
       debug: 4.4.3(supports-color@9.0.0)
       minimatch: 10.2.6
       semver: 7.8.5
@@ -2088,20 +2103,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)":
+  "@typescript-eslint/utils@8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)":
     dependencies:
-      "@eslint-community/eslint-utils": 4.10.1(eslint@10.8.1(supports-color@9.0.0))
-      "@typescript-eslint/scope-manager": 8.67.0
-      "@typescript-eslint/types": 8.67.0
-      "@typescript-eslint/typescript-estree": 8.67.0(supports-color@9.0.0)(typescript@6.0.3)
-      eslint: 10.8.1(supports-color@9.0.0)
+      "@eslint-community/eslint-utils": 4.10.1(eslint@10.8.0(supports-color@9.0.0))
+      "@typescript-eslint/scope-manager": 8.65.0
+      "@typescript-eslint/types": 8.65.0
+      "@typescript-eslint/typescript-estree": 8.65.0(supports-color@9.0.0)(typescript@6.0.3)
+      eslint: 10.8.0(supports-color@9.0.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/visitor-keys@8.67.0":
+  "@typescript-eslint/visitor-keys@8.65.0":
     dependencies:
-      "@typescript-eslint/types": 8.67.0
+      "@typescript-eslint/types": 8.65.0
       eslint-visitor-keys: 5.0.1
 
   "@ungap/structured-clone@1.3.3": {}
@@ -2123,7 +2138,7 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.3.0: {}
+  ansi-regex@6.2.2: {}
 
   ansi-styles@4.0.0:
     dependencies:
@@ -2245,9 +2260,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.1(supports-color@9.0.0):
+  eslint@10.8.0(supports-color@9.0.0):
     dependencies:
-      "@eslint-community/eslint-utils": 4.10.1(eslint@10.8.1(supports-color@9.0.0))
+      "@eslint-community/eslint-utils": 4.10.1(eslint@10.8.0(supports-color@9.0.0))
       "@eslint-community/regexpp": 4.12.2
       "@eslint/config-array": 0.23.5(supports-color@9.0.0)
       "@eslint/config-helpers": 0.7.0
@@ -2371,9 +2386,11 @@ snapshots:
 
   hosted-git-info@7.0.0:
     dependencies:
-      lru-cache: 10.2.0
+      lru-cache: 10.0.1
 
   husky@9.1.7: {}
+
+  ignore@5.0.0: {}
 
   ignore@5.2.0: {}
 
@@ -2467,6 +2484,8 @@ snapshots:
       p-locate: 5.0.0
 
   longest-streak@3.1.0: {}
+
+  lru-cache@10.0.1: {}
 
   lru-cache@10.2.0: {}
 
@@ -2885,7 +2904,7 @@ snapshots:
 
   strip-ansi@7.2.0:
     dependencies:
-      ansi-regex: 6.3.0
+      ansi-regex: 6.2.2
 
   supports-color@9.0.0:
     dependencies:
@@ -2920,13 +2939,13 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3):
+  typescript-eslint@8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3):
     dependencies:
-      "@typescript-eslint/eslint-plugin": 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3))(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
-      "@typescript-eslint/parser": 8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
-      "@typescript-eslint/typescript-estree": 8.67.0(supports-color@9.0.0)(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.67.0(eslint@10.8.1(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
-      eslint: 10.8.1(supports-color@9.0.0)
+      "@typescript-eslint/eslint-plugin": 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3))(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
+      "@typescript-eslint/parser": 8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
+      "@typescript-eslint/typescript-estree": 8.65.0(supports-color@9.0.0)(typescript@6.0.3)
+      "@typescript-eslint/utils": 8.65.0(eslint@10.8.0(supports-color@9.0.0))(supports-color@9.0.0)(typescript@6.0.3)
+      eslint: 10.8.0(supports-color@9.0.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -2962,7 +2981,7 @@ snapshots:
       concat-stream: 2.0.0
       debug: 4.4.3(supports-color@9.0.0)
       glob: 10.5.0
-      ignore: 5.2.0
+      ignore: 5.0.0
       is-empty: 1.2.0
       is-plain-obj: 4.1.0
       load-plugin: 5.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - ".github/scripts/*"
+
+minimumReleaseAge: 20160


### PR DESCRIPTION
## Summary

- enforce a 14-day minimum release age for pnpm dependency resolution
- remove the repository-level `packageManager` pin and let CI install the latest pnpm
- rebuild the lockfile with dependency versions that satisfy the new maturity policy

## Why

Delaying newly published packages reduces exposure to compromised or accidentally broken releases during their highest-risk window. Removing the `packageManager` field also keeps pnpm selection out of `package.json`, while the workflow remains runnable by explicitly requesting `latest`.

## Impact

Future installs reject package releases younger than 14 days. The current dependency floor moves to `eslint@^10.8.0` and `typescript-eslint@^8.65.0`, and CI resolves the latest pnpm release on every run.

## Validation

- `npx --yes pnpm@latest install --frozen-lockfile` (pnpm 11.22.0)
- `npx --yes pnpm@latest check`
- `git diff --check`
