### PR TITLE
[codex] Scope contribution Skill to external workspaces

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.18-1",
+  "version": "2026.8.19-1",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/skills/contribute-to-knowledge-base/SKILL.md
+++ b/skills/contribute-to-knowledge-base/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: contribute-to-knowledge-base
-description: Contribute changes to the canonical knowledge base. Use when the user wants to add, correct, reorganize, or remove Knowledge or Skills.
+description: Contribute changes to the canonical knowledge base from outside its source checkout. Use when the user wants to add, correct, reorganize, or remove Knowledge or Skills through the installed plugin.
 ---
 
 # Contribute to knowledge base
 
-Work in an isolated source checkout and treat installed plugin files as
-read-only runtime artifacts.
+When this Skill proceeds past the source-checkout guard, work in an isolated
+source checkout and treat installed plugin files as read-only runtime artifacts.
 
 ## Workflow
 
 1. Resolve paths relative to this `SKILL.md`. Read
    [`../../plugin.json`](../../plugin.json) and use its `repository` field as
-   the canonical upstream repository.
+   the canonical upstream repository. If the active workspace is already
+   within a source checkout of that repository, stop this Skill.
 2. Create a uniquely named temporary directory and clone the upstream default
    branch into it. Use this fresh checkout unless the user explicitly requests
    an existing source checkout.
@@ -34,6 +35,7 @@ read-only runtime artifacts.
 
 ## Completion criteria
 
-Finish only when the requested change follows the cloned repository's
-authoring rules, validation has been run, and a draft pull request exists or a
-publishing blocker has been reported with a recoverable checkout path.
+When this Skill proceeds past the source-checkout guard, finish only when the
+requested change follows the cloned repository's authoring rules, validation
+has been run, and a draft pull request exists or a publishing blocker has been
+reported with a recoverable checkout path.


### PR DESCRIPTION
## Summary

- scope `contribute-to-knowledge-base` to installed-plugin contributions from outside the canonical source checkout
- add an early source-checkout guard and scope the remaining workflow and completion criteria to the branch beyond it
- release the primary plugin as `2026.8.19-1`

## Why

An Agent with the plugin installed could select the usage Skill while already working in the knowledge-base source checkout. That workflow would then prepare another checkout even though the current workspace already exposes the repository's authoring capabilities.

## Impact

The installed Skill remains discoverable for contributions initiated from other workspaces. Inside the canonical source checkout, it exits before creating an isolated checkout.

## Validation

- `pnpm check`
- `pnpm plugin-version:update`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`
