### PR TITLE
[codex] Apply documentation guidance to knowledge additions

### DIFF
--- a/.agents/skills/add-to-knowledge-base/SKILL.md
+++ b/.agents/skills/add-to-knowledge-base/SKILL.md
@@ -28,20 +28,23 @@ Classify the material before choosing its destination.
    in that Skill or an appropriately scoped reference even when the prose
    sounds general or several Skills use it. Report why material in the last
    category was not integrated.
-5. For each Knowledge part, read
+5. If any accepted part is maintained explanatory or instructional text, read
+   [Good development documentation](../../../references/documentation/good-development-documentation.md)
+   and apply it throughout the applicable authoring workflow.
+6. For each Knowledge part, read
    [`references/add-knowledge.md`](references/add-knowledge.md) and complete
    that workflow.
-6. For each Skill part, read
+7. For each Skill part, read
    [`references/add-skill.md`](references/add-skill.md) and complete that
    workflow.
-7. For mixed material, finish the Knowledge branch first so the Skill can
+8. For mixed material, finish the Knowledge branch first so the Skill can
    reference the final canonical paths.
-8. When the final diff changes root `knowledge/**`, `references/**`, or
+9. When the final diff changes root `knowledge/**`, `references/**`, or
    `skills/**`, follow
    [`references/update-plugin-version.md`](references/update-plugin-version.md)
    after the content stabilizes.
-9. Review the combined result and report the classification, changed paths,
-   generated primary-plugin version when applicable, and validation performed.
+10. Review the combined result and report the classification, changed paths,
+    generated primary-plugin version when applicable, and validation performed.
 
 ## Completion criteria
 


### PR DESCRIPTION
## Summary

- make `add-to-knowledge-base` read the shared development-documentation reference for accepted explanatory or instructional material
- apply that guidance throughout the applicable Knowledge or Skill authoring workflow
- preserve the existing classification, branch ordering, and completion criteria

## Why

Repository-authoring work should use the same documentation guidance as the user-facing documentation Skills. Reading the shared packaged reference directly keeps one authoritative source without relying on Skill-to-Skill invocation.

## Impact

Agents authoring this repository will apply the shared documentation guidance after material is accepted and before entering the Knowledge or Skill branch. Rejected material remains unaffected. Because the change is confined to `.agents/**`, it does not change the installed primary plugin or require a plugin version update.

## Validation

- `python3 /Users/soulike/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/add-to-knowledge-base`
- `pnpm exec remark --frail --use remark-validate-links .agents/skills/add-to-knowledge-base/SKILL.md`
- `pnpm check`
- `git diff --check`
- independent read-only semantic comparison across Knowledge, Skill, mixed, and rejected-material branches
