### PR TITLE
Fix AI review permissions and test planning guidance

### DIFF
--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -90,3 +90,10 @@ published review and `AI Need Change` label. A missing or invalid verdict also
 fails closed. Re-running the same workflow run is idempotent after publication,
 while removing and adding `Ready for Review` creates a new auditable review
 request.
+
+Configure `AI review gate` as the required status check for pull requests. It
+runs after the prepare, review, and publish jobs and succeeds only when all
+three succeed. Each new pull-request head therefore remains blocked until a
+`Ready for Review` run succeeds. The workflow uses a different check name for
+unrelated label events because GitHub reports skipped jobs as successful; those
+events cannot satisfy the required AI review check.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     outputs:
       base_sha: ${{ steps.prepare.outputs.base_sha }}
       head_sha: ${{ steps.prepare.outputs.head_sha }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -178,3 +178,29 @@ jobs:
         env:
           AI_REVIEW_ARTIFACT_DIRECTORY: ${{ runner.temp }}/ai-review
         run: node .github/scripts/ai-review/gate.ts
+
+  gate:
+    name: ${{ github.event.label.name == 'Ready for Review' && 'AI review gate' || 'Ignore unrelated label' }}
+    if: ${{ always() && github.event.label.name == 'Ready for Review' }}
+    needs:
+      - prepare
+      - review
+      - publish
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Require every AI review job to succeed
+        env:
+          PREPARE_RESULT: ${{ needs.prepare.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          REVIEW_RESULT: ${{ needs.review.result }}
+        run: |
+          printf 'Prepare: %s\nReview: %s\nPublish: %s\n' \
+            "$PREPARE_RESULT" "$REVIEW_RESULT" "$PUBLISH_RESULT"
+
+          if [[ "$PREPARE_RESULT" != "success" ||
+                "$REVIEW_RESULT" != "success" ||
+                "$PUBLISH_RESULT" != "success" ]]; then
+            printf 'Every AI review job must succeed.\n' >&2
+            exit 1
+          fi

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.19-3",
+  "version": "2026.8.21-1",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/references/software-testing/test-effectiveness.md
+++ b/references/software-testing/test-effectiveness.md
@@ -21,6 +21,14 @@ A change in externally observable behavior normally needs coverage for the new c
 
 Static guarantees stop at their actual boundary. A compiler can prove properties of code it checks, but a type annotation on data from a network, database, file, or deserializer is not runtime validation. Parsing, normalization, compatibility handling, and rejection at those seams are behavior and can require tests.
 
+## Establish the local behavior boundary
+
+A project test must exercise behavior owned by code that the project's declared test environment can execute and must observe that behavior's effect. File type does not decide this boundary: configuration interpreted by a local executable can participate in local behavior, while source code whose relevant effect occurs only inside an unavailable external system does not provide a local test seam.
+
+Treat a declaration or configuration value consumed only by an external platform as input to that platform, not as local behavior merely because changing the value changes the remote outcome. Use the platform's applicable syntax or schema validation, and verify the effect through the real integration when that is practical and proportionate. Parsing the file locally and asserting that it contains the selected value restates the source; it does not exercise the external behavior or supply an independent oracle.
+
+When local code interprets, transforms, validates, or transmits that input, test the owned effect through that code's interface rather than asserting the input literal. If no such local path exists, record that no local automated test is owed and identify the non-test validation that applies.
+
 ## Find marginal coverage
 
 Several common test shapes add little or no independent protection:

--- a/skills/design-and-review-tests/SKILL.md
+++ b/skills/design-and-review-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-and-review-tests
-description: Design and review automated tests. Use when deciding whether a behavior change requires a test; adding or modifying tests; reviewing test content or coverage; assessing redundant or ineffective tests; or changing test discovery, conditional validation selection, or runner configuration.
+description: Decide whether automated tests should be added and, when justified, design and review effective test plans and coverage. Use whenever planning to add or modify tests; deciding whether a change requires a test; reviewing test content or coverage; assessing redundant or ineffective tests; or changing test discovery, conditional validation selection, or runner configuration.
 ---
 
 # Design and review tests
@@ -39,37 +39,47 @@ Finish this step when the behavior under review, applicable local rules, and
 the commands that can establish evidence are known and, for a change review,
 the two-way review inventory is complete.
 
-## Decide what protection is owed
+## Decide whether to add a test
 
-1. Apply the loaded Test effectiveness criteria to each changed behavior and
-   review concern. Inspect production code as well as changed tests when
-   reviewing coverage.
-2. Record the named contract, realistic fault, existing evidence path, and any
-   uncovered boundary. State the reference-backed rationale when no new test is
-   owed.
-3. Identify migration-only scaffolding separately from permanent protection.
+1. Treat every plan or request to add or modify a test as a proposal to
+   evaluate before implementation, not as evidence that a test is owed.
+2. Apply the loaded Test effectiveness criteria, including its local behavior
+   boundary, to each changed behavior and review concern. Inspect production
+   code as well as changed tests when reviewing coverage.
+3. Record the named local behavior, realistic fault, existing evidence path,
+   and any uncovered boundary. Classify the result as no test owed, existing
+   coverage sufficient, or a new or modified test required. State the
+   reference-backed rationale when no new test is owed.
+4. Identify migration-only scaffolding separately from permanent protection.
 
-Finish this step when every changed behavior or review concern has one evidence
-path or a concrete, supportable coverage gap.
+Finish this step when every changed behavior, proposed test, or review concern
+has a supported disposition. Do not design or implement a test until this step
+identifies a concrete coverage gap in local executable behavior.
 
-## Choose the owning test
+## Validate the test plan
 
-1. Use the ownership, oracle, test-structure, and test-double criteria in Test
-   effectiveness to select the narrowest test that can detect the named fault.
-2. Apply Reliable test execution to fixtures, ambient state, cleanup,
+1. For each required test, use the ownership, oracle, test-structure, and
+   test-double criteria in Test effectiveness to select the narrowest test that
+   can detect the named fault.
+2. Name the owning seam, independent oracle, observable failure, fixture, and
+   project-declared command that will execute the test.
+3. Apply Reliable test execution to fixtures, ambient state, cleanup,
    concurrency, clocks, retries, and supported-platform behavior whenever those
    concerns are present.
-3. Fit the test to the active project's conventions and available seams without
+4. Fit the test to the active project's conventions and available seams without
    weakening the contract identified above.
 
 Finish this step when each proposed or reviewed test can fail for its named
-fault without relying on unrelated behavior or ambient state.
+fault, pass for the intended behavior, and do both without merely restating the
+source under test or relying on unrelated behavior or ambient state.
 
 ## Implement or report
 
-When edits are authorized, implement the smallest coverage change that closes
-the identified gap and preserve unrelated user work. When the request is only
-to assess or review, report findings and proposed tests without editing.
+When edits are authorized, implement the smallest validated coverage change
+that closes the identified gap and preserve unrelated user work. When no test
+is owed, do not create one; perform the applicable non-test validation. When
+the request is only to assess or review, report findings and proposed tests
+without editing.
 
 For runner, discovery, or conditional-validation work, apply the corresponding
 Reliable test execution criteria. Isolate mechanical changes from intentional

--- a/skills/design-and-review-tests/agents/openai.yaml
+++ b/skills/design-and-review-tests/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Design and Review Tests"
   short_description: "Design focused tests and review coverage"
-  default_prompt: "Use $design-and-review-tests to decide what this change must test and review the resulting coverage."
+  default_prompt: "Use $design-and-review-tests to decide whether this change needs automated tests and, if so, validate the test plan and coverage."


### PR DESCRIPTION
## Summary

- grant the AI review prepare job write access to pull requests so it can minimize stale workflow comments
- add an `AI review gate` check that succeeds only when prepare, review, and publish all succeed, while preventing unrelated label events from satisfying the required check
- invoke `design-and-review-tests` whenever tests are planned, first deciding whether local executable behavior needs coverage and then validating the proposed plan
- document that assertions over literals in externally consumed configuration do not test local behavior
- release the primary plugin as `2026.8.21-1`

## Validation

- `pnpm check`
- `actionlint .github/workflows/ai-review.yml`
- workflow YAML parsing
- `python3 /Users/soulike/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/design-and-review-tests`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`
- independent semantic review: no findings before the aggregate-gate follow-up

The live `pull_request_target` behavior and aggregate check must be verified after merge because GitHub loads this workflow from the default branch.