### PR TITLE
Fix AI review gate label permissions

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -94,8 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Check out trusted gate
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

- grant the trusted AI review gate pull request write permission so it can update verdict labels on pull requests
- remove the redundant issues write permission

## Failure

Run 32465075338 completed the Copilot review, then the gate failed with HTTP 403 while removing the AI Approved label. Its effective token had Issues: write but only PullRequests: read.

## Validation

- pnpm check
- git diff --check

No local regression test is added because GitHub alone interprets and enforces workflow token permissions; a YAML assertion would only restate the configuration.

## Bootstrap limitation

This PRs own AI review run 32465992750 fails with the same 403 because pull_request_target loads the workflow from the current default branch. The corrected permission cannot take effect until this change reaches main. A new pull request event after merge will provide the integration proof.