### PR TITLE
Fail AI review gate for draft pull requests

### DIFF
--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -6,8 +6,10 @@ the pull request opens, reopens, becomes ready for review, or receives a new
 push. A per-pull-request concurrency group cancels the older run when another
 push arrives.
 
-Draft and closed events skip Copilot and remove the AI verdict labels. A draft
-pull request starts its first review when it becomes ready for review.
+Draft and closed events skip Copilot and remove the AI verdict labels. The gate
+fails while a pull request is a draft, then the pull request starts its first
+review when it becomes ready for review. A closed pull request is not
+applicable to the gate.
 
 ## Trust and permission boundary
 

--- a/.github/scripts/ai-review/gate.test.ts
+++ b/.github/scripts/ai-review/gate.test.ts
@@ -205,12 +205,31 @@ test("clears verdict labels when the review job fails", async () => {
   assert.equal(client.pullRequestReads, 0);
 });
 
-test("clears verdict labels without requiring a review for a draft", async () => {
+test("clears verdict labels and fails the gate for a draft", async (t) => {
+  for (const context of [
+    { action: "opened" as const, isDraft: true },
+    { action: "converted_to_draft" as const, isDraft: true },
+  ]) {
+    await t.test(context.action, async () => {
+      const client = new FakeGitHubClient([], []);
+
+      await assert.rejects(
+        enforceReviewGate(client, gateContext(context)),
+        /draft pull request/u,
+      );
+
+      assert.deepEqual([...client.labels], []);
+      assert.equal(client.pullRequestReads, 0);
+    });
+  }
+});
+
+test("clears verdict labels without requiring a review after close", async () => {
   const client = new FakeGitHubClient([], []);
 
   const result = await enforceReviewGate(
     client,
-    gateContext({ action: "converted_to_draft" as const, isDraft: true }),
+    gateContext({ action: "closed" as const }),
   );
 
   assert.equal(result, "not-applicable");

--- a/.github/scripts/ai-review/gate.ts
+++ b/.github/scripts/ai-review/gate.ts
@@ -16,7 +16,7 @@ const client = new GitHubClient(required("GITHUB_TOKEN"), config.repository);
 const result = await enforceReviewGate(client, { ...config, ...event });
 
 if (result === "not-applicable") {
-  console.log("AI review is not applicable to a draft or closed pull request.");
+  console.log("AI review is not applicable to a closed pull request.");
 } else {
   console.log("AI review approved.");
 }

--- a/.github/scripts/ai-review/review-gate.ts
+++ b/.github/scripts/ai-review/review-gate.ts
@@ -101,13 +101,14 @@ export async function enforceReviewGate(
   client: ReviewGateClient,
   context: ReviewGateContext,
 ): Promise<"approved" | "not-applicable"> {
-  if (
-    context.action === "closed" ||
-    context.action === "converted_to_draft" ||
-    context.isDraft
-  ) {
+  if (context.action === "closed") {
     await clearVerdictLabels(client, context.prNumber);
     return "not-applicable";
+  }
+
+  if (context.action === "converted_to_draft" || context.isDraft) {
+    await clearVerdictLabels(client, context.prNumber);
+    throw new Error("AI review cannot pass for a draft pull request.");
   }
 
   if (!isTrustedAuthorAssociation(context.authorAssociation)) {


### PR DESCRIPTION
## Summary

- fail the AI review gate for draft pull requests after clearing verdict labels
- preserve the not-applicable behavior for closed pull requests
- cover opened drafts and converted-to-draft events with executable regression tests
- document the updated review lifecycle

## Root cause

The review job was skipped for draft pull requests, but the always-running gate returned `not-applicable` with exit code 0. GitHub therefore reported `AI review gate` as successful.

## Test plan

- `pnpm check`
- `git diff --check HEAD^ HEAD`

## Live verification

This workflow uses `pull_request_target`, so this PR's own draft run loads the pre-fix workflow and gate code from the default branch. After merge, trigger a fresh draft or converted-to-draft event and confirm that `AI review gate` fails.