### PR TITLE
Clarify post-push PR comment handling

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.26-2",
+  "version": "2026.8.26-3",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/skills/watch-pull-request/SKILL.md
+++ b/skills/watch-pull-request/SKILL.md
@@ -136,17 +136,28 @@ Skip this step when no autonomous work remains.
    source SHA changed, apply the Autonomy policy's concurrent-head rule, then
    repeat focused and aggregate validation against the resulting identity.
 7. Perform direct bounded publication only after the Autonomy policy's
-   publication compare-and-set and publication-effects rules pass, then begin a
-   new complete observation cycle.
-8. For an autonomous item that needs no code change, revalidate its evidence
+   publication compare-and-set and publication-effects rules pass. Reconcile
+   the published head, then complete a new observation and classification cycle
+   before performing any follow-up mutation.
+8. For every top-level comment or review thread whose disposition depends on a
+   published fix, revalidate its concern against the reconciled current head,
+   then reply to that comment or in that thread. Give every associated item its
+   own disposition when one fix addresses several items; one reply does not
+   dispose of the others. State what changed, the published commit or head,
+   validation performed, and any remaining limitation. Resolve each review
+   thread only when the Autonomy policy's resolution criteria are all
+   satisfied.
+9. For an autonomous item that needs no code change, revalidate its evidence
    and complete PR identity immediately before performing its exact allowlisted
    mutation.
-9. Reply in the original thread when one exists. State what changed or why no
-   change was appropriate, the current commit or head context, validation
-   performed, and any remaining limitation. Resolve the thread only when the
-   Autonomy policy's resolution criteria are all satisfied.
 10. Apply the Autonomy policy's uncertain-effect reconciliation rule before
     replaying a mutation whose outcome is unknown.
+
+Do not enter **Wait and resume** until every item handled in the cycle is
+accounted for and every attempted remote mutation has a known result: each item
+addressed by a published fix has its required reply, each eligible review-thread
+resolution has a reconciled result, and each item whose reply must wait for a
+human decision is recorded under the Autonomy policy without a holding reply.
 
 Do not impose an arbitrary total cycle limit. Continue only while each cycle
 has an evidence-backed reason to advance the PR, and apply the Autonomy
@@ -155,7 +166,8 @@ policy's remediation-loop stopping rule after every cycle.
 Finish this step when every selected fix is represented by one validated local
 commit, the aggregate branch result passed available required validation, the
 commits were pushed together without rewriting history, and every remote
-mutation has a known reconciled result.
+mutation has a known reconciled result and every handled comment or thread is
+accounted for.
 
 ## Wait and resume
 

--- a/skills/watch-pull-request/SKILL.md
+++ b/skills/watch-pull-request/SKILL.md
@@ -139,25 +139,28 @@ Skip this step when no autonomous work remains.
    publication compare-and-set and publication-effects rules pass. Reconcile
    the published head, then complete a new observation and classification cycle
    before performing any follow-up mutation.
-8. For every top-level comment or review thread whose disposition depends on a
-   published fix, revalidate its concern against the reconciled current head,
-   then reply to that comment or in that thread. Give every associated item its
-   own disposition when one fix addresses several items; one reply does not
-   dispose of the others. State what changed, the published commit or head,
-   validation performed, and any remaining limitation. Resolve each review
-   thread only when the Autonomy policy's resolution criteria are all
-   satisfied.
-9. For an autonomous item that needs no code change, revalidate its evidence
-   and complete PR identity immediately before performing its exact allowlisted
-   mutation.
+8. For every autonomously handled top-level comment or review thread,
+   revalidate its concern and disposition against the current complete PR
+   identity immediately before replying, then reply to that comment or in that
+   thread. Give every associated item its own disposition when one fix addresses
+   several items; one reply does not dispose of the others. For a published fix,
+   state what changed, the published commit or head, validation performed, and
+   any remaining limitation. When no code change was appropriate, state why,
+   the supporting evidence and current head, and any remaining limitation.
+   Resolve each review thread only when the Autonomy policy's resolution
+   criteria are all satisfied.
+9. For an autonomous item that needs neither a code change nor a discussion
+   reply, revalidate its evidence and complete PR identity immediately before
+   performing its exact allowlisted mutation.
 10. Apply the Autonomy policy's uncertain-effect reconciliation rule before
     replaying a mutation whose outcome is unknown.
 
 Do not enter **Wait and resume** until every item handled in the cycle is
 accounted for and every attempted remote mutation has a known result: each item
-addressed by a published fix has its required reply, each eligible review-thread
-resolution has a reconciled result, and each item whose reply must wait for a
-human decision is recorded under the Autonomy policy without a holding reply.
+handled through a top-level comment or review thread has its required reply,
+each eligible review-thread resolution has a reconciled result, and each item
+whose reply must wait for a human decision is recorded under the Autonomy policy
+without a holding reply.
 
 Do not impose an arbitrary total cycle limit. Continue only while each cycle
 has an evidence-backed reason to advance the PR, and apply the Autonomy

--- a/skills/watch-pull-request/references/autonomy-policy.md
+++ b/skills/watch-pull-request/references/autonomy-policy.md
@@ -270,16 +270,18 @@ the observed thread version or last comment when available, and re-fetch after
 a conflict.
 
 When the provider exposes only an unconditional thread identifier mutation,
-resolution remains autonomous only when the provider can also restore the
-unresolved state. The final pre-resolution read must confirm that the complete
-PR identity still matches the verified head and every current comment is
-answered. Immediately retrieve a new complete PR state and thread after
-resolution. Reclassify any identity, thread-state, or comment change; when the
-resolution criteria no longer hold, restore the unresolved state before
-handling the new disposition. Reconcile an unknown resolution or restoration
-result under the uncertain-effect rule before retrying it. When restoration is
-unavailable or its result cannot be reconciled, keep unconditional resolution
-as human intervention required.
+resolution remains autonomous after the final pre-resolution read confirms
+that the complete PR identity still matches the verified head and every current
+comment is answered. This accepts the residual race that new activity can
+arrive before the mutation because comments remain visible and the resolved
+marker is reversible. Immediately retrieve a new complete PR state and thread
+after resolution, then reclassify any identity, thread-state, or comment
+change. Treat concurrent activity as current work regardless of the resolved
+marker. Do not issue an unconditional restoration mutation because it cannot
+prove ownership of the current thread state; when the fresh disposition
+requires the thread to be unresolved and the provider cannot guard that
+restoration, record human intervention required. Reconcile an unknown
+resolution result under the uncertain-effect rule before retrying it.
 
 Keep the thread unresolved when the reply asks a question, proposes alternatives,
 depends on a human decision, provides a partial fix, or cannot be verified. An

--- a/skills/watch-pull-request/references/autonomy-policy.md
+++ b/skills/watch-pull-request/references/autonomy-policy.md
@@ -263,21 +263,23 @@ of these are true:
 4. A reply records the disposition and relevant evidence.
 5. No part of the thread remains unanswered.
 
-After those semantic criteria pass, re-fetch the complete thread immediately
-before resolution and reclassify it when the thread state or comments changed.
-Use a provider-supported compare-and-set tied to the observed thread version or
-last comment when available, and re-fetch after a conflict.
+After those semantic criteria pass, re-fetch the complete PR state and thread
+immediately before resolution. Reclassify when the complete PR identity, thread
+state, or comments changed. Use a provider-supported compare-and-set tied to
+the observed thread version or last comment when available, and re-fetch after
+a conflict.
 
 When the provider exposes only an unconditional thread identifier mutation,
-resolution remains autonomous after the final pre-resolution read confirms
-that every current comment is answered. Immediately re-fetch the complete
-thread after resolution. Treat a concurrent comment as new activity and
-reclassify it. If it raises an unanswered concern, unresolve the thread when the
-provider supports it, then handle the new disposition. When the provider cannot
-restore the unresolved state, answer an autonomous concern immediately or
-record human intervention required for a concern that cannot yet be answered.
-Reconcile an unknown mutation result under the uncertain-effect rule before
-retrying it.
+resolution remains autonomous only when the provider can also restore the
+unresolved state. The final pre-resolution read must confirm that the complete
+PR identity still matches the verified head and every current comment is
+answered. Immediately retrieve a new complete PR state and thread after
+resolution. Reclassify any identity, thread-state, or comment change; when the
+resolution criteria no longer hold, restore the unresolved state before
+handling the new disposition. Reconcile an unknown resolution or restoration
+result under the uncertain-effect rule before retrying it. When restoration is
+unavailable or its result cannot be reconciled, keep unconditional resolution
+as human intervention required.
 
 Keep the thread unresolved when the reply asks a question, proposes alternatives,
 depends on a human decision, provides a partial fix, or cannot be verified. An

--- a/skills/watch-pull-request/references/autonomy-policy.md
+++ b/skills/watch-pull-request/references/autonomy-policy.md
@@ -134,8 +134,9 @@ The watch request authorizes these operations when the autonomy gate passes:
 - run local validation;
 - create ordinary commits and push them normally to the existing PR branch;
 - reply to top-level comments and review threads;
-- resolve review threads only through a provider-supported atomic
-  compare-and-set tied to the observed thread version or last comment;
+- resolve review threads after complete disposition, using an atomic
+  compare-and-set when available or the pre- and post-resolution reconciliation
+  required below;
 - rerun one clearly transient CI replay unit for the same PR identity under the
   complete-effect rule below; and
 - update the PR title or description only through a provider-supported atomic
@@ -262,12 +263,21 @@ of these are true:
 4. A reply records the disposition and relevant evidence.
 5. No part of the thread remains unanswered.
 
-After those semantic criteria pass, require the provider to reject the
-resolution if the thread or last comment changed since observation. Re-fetch
-and reclassify after a compare-and-set conflict. When the provider exposes only
-an unconditional thread identifier mutation, keep the reply autonomous but
-leave resolution as human intervention required; a final read immediately
-before mutation cannot close the race.
+After those semantic criteria pass, re-fetch the complete thread immediately
+before resolution and reclassify it when the thread state or comments changed.
+Use a provider-supported compare-and-set tied to the observed thread version or
+last comment when available, and re-fetch after a conflict.
+
+When the provider exposes only an unconditional thread identifier mutation,
+resolution remains autonomous after the final pre-resolution read confirms
+that every current comment is answered. Immediately re-fetch the complete
+thread after resolution. Treat a concurrent comment as new activity and
+reclassify it. If it raises an unanswered concern, unresolve the thread when the
+provider supports it, then handle the new disposition. When the provider cannot
+restore the unresolved state, answer an autonomous concern immediately or
+record human intervention required for a concern that cannot yet be answered.
+Reconcile an unknown mutation result under the uncertain-effect rule before
+retrying it.
 
 Keep the thread unresolved when the reply asks a question, proposes alternatives,
 depends on a human decision, provides a partial fix, or cannot be verified. An


### PR DESCRIPTION
## Summary

- require a fresh observation and classification cycle after publishing fixes
- reply separately to every top-level comment or review thread addressed by a published fix
- prevent the watch from waiting until handled comments, threads, and remote mutations are reconciled
- bump the primary plugin version to 2026.8.26-3

## Validation

- pnpm check