### PR TITLE
Clarify review fix commit boundaries

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.27-2",
+  "version": "2026.8.27-3",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/skills/watch-pull-request/references/publish-fixes.md
+++ b/skills/watch-pull-request/references/publish-fixes.md
@@ -10,6 +10,20 @@ required by the active project, and apply the destination, credential,
 execution, side-effect, and side-band boundaries established by the watch
 contract.
 
+## Prepare focused commits
+
+Partition the completed work into independently reviewable fix units. Create
+one focused ordinary commit for each independently remediable concern. When
+several comments or review threads identify the same concern, let one commit
+own that concern. Combine concerns only when they share a root cause or must
+change together to preserve a coherent invariant, and keep that coupled fix in
+one commit.
+
+Name the technical result in each commit message so the corresponding replies
+can identify the commit that handled their concern. Prepare every commit for
+the current observation cycle before the pre-push check; the cycle publishes
+all of them together with one push.
+
 ## Run the pre-push check
 
 Immediately before every push attempt:


### PR DESCRIPTION
## Summary

- create one focused commit for each independently remediable review concern
- keep comments sharing one concern, and inseparable coupled concerns, in one coherent commit
- prepare all commits within the current observation cycle and publish them together with one push
- bump the primary plugin version to `2026.8.27-3`

## Validation

- `pnpm check`
- `git diff --check`