### PR TITLE
Close cumulative drift validation loop

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.27-3",
+  "version": "2026.8.27-4",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/skills/watch-pull-request/references/capture-pr-state.md
+++ b/skills/watch-pull-request/references/capture-pr-state.md
@@ -5,6 +5,8 @@ Retrieve one complete current snapshot from every applicable PR surface:
 - PR number, state, draft or terminal state, title, description, and
   writeability;
 - base repository, ref, and SHA, together with source repository, ref, and SHA;
+- complete base-to-current-head commit history and aggregate diff, including
+  changes published by earlier observation cycles;
 - submitted reviews, aggregate review decision, requested reviewers and teams,
   and required approval state;
 - complete paginated review threads and replies, including resolved and
@@ -19,6 +21,11 @@ Use a thread-aware interface when thread state matters. A flat comment list or
 summary is not a complete snapshot. Record the complete content and state of
 each review thread so a later reply-and-resolve step can compare it with this
 baseline.
+
+Inspect the aggregate diff and commit history as one current artifact even when
+the latest activity concerns only one commit, comment, or thread. Supply that
+complete change as evidence to the autonomy gate's cumulative-drift decision;
+the latest incremental diff is not a substitute.
 
 Treat the PR number and state, base repository/ref/SHA, and source
 repository/ref/SHA as one complete PR identity. Separately record the source

--- a/skills/watch-pull-request/references/publish-fixes.md
+++ b/skills/watch-pull-request/references/publish-fixes.md
@@ -19,10 +19,27 @@ own that concern. Combine concerns only when they share a root cause or must
 change together to preserve a coherent invariant, and keep that coupled fix in
 one commit.
 
+Run focused validation for each fix unit before creating its commit. The
+validation must directly cover the concern that the commit owns and preserve
+the active project's required checks.
+
 Name the technical result in each commit message so the corresponding replies
 can identify the commit that handled their concern. Prepare every commit for
-the current observation cycle before the pre-push check; the cycle publishes
-all of them together with one push.
+the current observation cycle before the pre-push check.
+
+Before that check, inspect the complete aggregate diff from the captured base
+SHA through the proposed local head. Include both fixes published by earlier
+cycles and every unpublished commit from the current cycle. Run the aggregate
+validation required by the active project, then reapply the autonomy gate and
+its cumulative-drift criteria to the proposed result. Each commit passing on
+its own does not establish that their combined result remains within the
+accepted intent and mutation boundary.
+
+When the aggregate result fails that gate, preserve the unpublished commits,
+freeze mutation, record the fix units and evidence that produced the drift,
+and hand off the governing decision. Do not push or post replies that depend on
+those commits. When it passes, the cycle publishes all prepared commits
+together with one push.
 
 ## Run the pre-push check
 


### PR DESCRIPTION
## Summary

- capture the complete base-to-current-head commit history and aggregate diff in every observation cycle
- require focused validation for each review fix unit before its commit
- reapply the autonomy and cumulative-drift gates to the full proposed head before publication
- freeze publication and dependent replies when individually valid fixes drift in aggregate
- bump the primary plugin version to `2026.8.27-4`

## Validation

- `pnpm check`
- `git diff --check`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`