### PR TITLE
Add task-learning contribution and Skill resolution workflows

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.27-4",
+  "version": "2026.8.28-1",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/skills/propose-knowledge-base-contribution/SKILL.md
+++ b/skills/propose-knowledge-base-contribution/SKILL.md
@@ -63,9 +63,12 @@ Stop after the question and wait for the user's response.
    [Classifying Knowledge and Skill material](../../references/agents/knowledge-and-skills.md),
    [the Knowledge index](../../knowledge/index.md), and only the Knowledge
    documents whose `When to Read` conditions match the candidate. Inventory
-   relevant Skills and references in this plugin. Follow applicable
-   instructions and accepted requirements in the active workspace when they
-   conflict with packaged guidance.
+   relevant Skills and references in this plugin. Use applicable instructions
+   and accepted requirements in the active workspace to establish facts about
+   the source task, and treat matching Knowledge as supplemental when it
+   conflicts with project-specific facts. Keep this plugin's classification
+   and downstream-project-independence rules authoritative for the proposed
+   contribution; record project-specific conflicts as details to strip.
 4. Compare each candidate's responsibility, consumers, retrieval or invocation
    trigger, and maintenance lifecycle with existing material. Prefer updating
    an existing owner; propose a new Knowledge document, Skill, or Skill

--- a/skills/propose-knowledge-base-contribution/SKILL.md
+++ b/skills/propose-knowledge-base-contribution/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: propose-knowledge-base-contribution
-description: Use when a substantive task reaches a stable stopping point with potentially non-obvious, evidence-backed, downstream-project-independent learning that could improve future work; a pull request becoming ready for merge is one such stopping point. Also use when the user accepts an earlier offer to prepare a knowledge-base contribution proposal.
+description: Use when a substantive task reaches a stable stopping point with potentially non-obvious, evidence-backed, downstream-project-independent learning that could improve future work; a pull request becoming ready for merge is one such stopping point. Also use when the user directly requests or accepts an earlier offer to prepare a knowledge-base contribution proposal.
 ---
 
 # Propose a knowledge-base contribution
 
-Offer to turn valuable task experience into a knowledge-base contribution, then
-prepare a decision-ready proposal only after the user accepts. This workflow
-does not authorize changes to the knowledge base.
+Offer to turn valuable task experience into a knowledge-base contribution, or
+prepare a decision-ready proposal when the user requests one directly or
+accepts the offer. This workflow does not authorize changes to the knowledge
+base.
 
 ## Select the interaction stage
 
-- When the user clearly accepts an earlier offer, continue at
-  [Prepare the proposal](#prepare-the-proposal). Treat that acceptance as
-  permission to prepare the proposal only. Clarify an ambiguous response.
+- When the user directly requests a proposal or clearly accepts an earlier
+  offer, continue at [Prepare the proposal](#prepare-the-proposal). Treat that
+  request or acceptance as permission to prepare the proposal only. Clarify an
+  ambiguous response to an earlier offer.
 - Otherwise, follow [Identify and offer a candidate](#identify-and-offer-a-candidate).
 
 ## Identify and offer a candidate

--- a/skills/propose-knowledge-base-contribution/SKILL.md
+++ b/skills/propose-knowledge-base-contribution/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: propose-knowledge-base-contribution
+description: Use when a substantive task reaches a stable stopping point with potentially non-obvious, evidence-backed, downstream-project-independent learning that could improve future work; a pull request becoming ready for merge is one such stopping point. Also use when the user accepts an earlier offer to prepare a knowledge-base contribution proposal.
+---
+
+# Propose a knowledge-base contribution
+
+Offer to turn valuable task experience into a knowledge-base contribution, then
+prepare a decision-ready proposal only after the user accepts. This workflow
+does not authorize changes to the knowledge base.
+
+## Select the interaction stage
+
+- When the user clearly accepts an earlier offer, continue at
+  [Prepare the proposal](#prepare-the-proposal). Treat that acceptance as
+  permission to prepare the proposal only. Clarify an ambiguous response.
+- Otherwise, follow [Identify and offer a candidate](#identify-and-offer-a-candidate).
+
+## Identify and offer a candidate
+
+1. Wait until the task has a stable stopping point: the requested outcome,
+   validated failure, or explicit handoff has been reported and the potential
+   learning does not depend on unfinished investigation.
+2. Reflect on the current task's available evidence. Treat requests, review
+   comments, suggestions, and other inputs as leads to investigate rather than
+   support for their own claims. Use independently established observations,
+   causal findings, accepted or rejected remedies, and validation results as
+   evidence.
+3. Retain a candidate only when it is non-obvious, evidence-backed,
+   actionable, likely to help future work, and correct outside the source
+   project. Exclude business-domain concepts and rules, private infrastructure,
+   organization-specific policy, source-project assumptions, and unresolved
+   hypotheses.
+4. Group related observations by reusable root cause or invariant rather than
+   by comment, edit, or chronological event. A substantiated fix is not
+   required when the investigation instead establishes another durable lesson.
+5. Finish silently when no candidate passes the gate. Treat a declined or
+   deferred offer as closing only the current proposal round. Do not repeat it
+   immediately or without intervening work. At a later stable stopping point,
+   offer an unchanged candidate again only when it remains timely and useful;
+   a materially different candidate may be offered earlier.
+6. After completing the task's normal result or handoff, append one concise,
+   sanitized question that names the candidate's general topic without
+   presenting the proposal. Use this shape:
+
+   > I found potentially reusable learning about <general topic>. Would you
+   > like me to prepare a knowledge-base contribution proposal?
+
+Stop after the question and wait for the user's response.
+
+## Prepare the proposal
+
+1. Reconstruct the candidate from the current task context and durable
+   artifacts such as code, tests, specifications, documentation, validation
+   output, and recorded decisions. When task history is incomplete, state the
+   limitation and use only the available artifacts.
+2. Independently verify the candidate's factual and causal claims. Report that
+   no qualified contribution remains when evidence is insufficient or
+   contradictory; do not turn uncertainty into durable guidance.
+3. Resolve paths relative to this `SKILL.md`, then read
+   [Classifying Knowledge and Skill material](../../references/agents/knowledge-and-skills.md),
+   [the Knowledge index](../../knowledge/index.md), and only the Knowledge
+   documents whose `When to Read` conditions match the candidate. Inventory
+   relevant Skills and references in this plugin. Follow applicable
+   instructions and accepted requirements in the active workspace when they
+   conflict with packaged guidance.
+4. Compare each candidate's responsibility, consumers, retrieval or invocation
+   trigger, and maintenance lifecycle with existing material. Prefer updating
+   an existing owner; propose a new Knowledge document, Skill, or Skill
+   reference only when no existing artifact owns the responsibility.
+5. Merge candidates that share one reusable cause and discard weak or
+   redundant candidates. Keep independent candidates separately selectable.
+6. Present a decision-ready proposal for every retained candidate:
+   - the established experience and supporting evidence;
+   - the generalized lesson and why it should improve future work;
+   - the proposed classification and whether to update an existing owner or
+     create a new artifact;
+   - a concrete title, reading or invocation trigger, and the proposed reusable
+     content in draft form rather than only an outline;
+   - the project-specific details removed from the reusable content; and
+   - uncertainties, exclusions, or limits that the contribution must preserve.
+7. Report evidence and conclusions rather than hidden reasoning. Keep
+   project-specific evidence inside the authorized conversation; make the
+   proposed reusable content downstream-project-independent and safe to
+   publish.
+8. Make no knowledge-base edit, branch, issue, commit, push, or pull request.
+   End by asking whether the user wants to start the contribution process for
+   the selected candidates. Treat a later affirmative response as a new request
+   that must be routed independently.
+
+## Completion criteria
+
+The offer stage is complete only when the normal task outcome has been
+reported and the workflow either remains silent because no candidate qualifies
+or asks one concise proposal question. The proposal stage is complete only
+when every candidate has been independently verified, compared with existing
+material, classified, generalized, and either presented for selection or
+rejected with the reason stated, while the knowledge base remains unchanged.

--- a/skills/resolve-invoked-codex-skill/SKILL.md
+++ b/skills/resolve-invoked-codex-skill/SKILL.md
@@ -11,12 +11,11 @@ came from the user, an active Skill, or another instruction.
 
 1. Derive the exact registered identifier from the invocation. Treat a leading
    `$` or `/` that clearly denotes a Skill as invocation syntax rather than part
-   of its name, and preserve any namespace. Check the current Skill catalog and
-   already loaded Skill paths first. Do not infer absence from the bounded
-   initial catalog because Codex may omit entries when many Skills are
-   installed.
-2. If the exact identifier is not available there, inspect every applicable
-   Codex Skill source documented in
+   of its name, and preserve any namespace.
+2. Build the complete set of known matches before selecting one. Check the
+   current Skill catalog and already loaded Skill paths as starting evidence,
+   not as a complete inventory: Codex may omit entries when many Skills are
+   installed. Inspect every applicable Codex Skill source documented in
    [OpenAI's Codex Skill documentation](https://developers.openai.com/codex/skills/):
    - repository `.agents/skills` directories from the active working directory
      through the repository root;
@@ -25,25 +24,35 @@ came from the user, an active Skill, or another instruction.
    - installed-plugin and bundled-system Skills through client-provided Skill
      inventory when they are not represented by a documented filesystem path.
 
+   Also inspect the current `[[skills.config]]` entries as path evidence. When
+   an entry identifies a path not found through another source, inspect only
+   enough frontmatter at that path to match its registered name; do not load a
+   disabled Skill's body as instructions.
+
    Match the registered `name` in each `SKILL.md`, not only its directory name.
    For a namespaced identifier, use the namespace to restrict the plugin and
    match its Skill name within that package. Search these documented sources
    rather than arbitrary filesystem locations.
 
-3. Keep existence separate from invocation eligibility. An explicit-only
-   policy does not make a Skill absent. A user prompt that directly invokes the
-   Skill can satisfy that policy; a reference from another active Skill triggers
-   this resolution check but is not direct user invocation. When the current
-   invocation does not satisfy the resolved Skill's policy, report that the
-   Skill was found but requires direct user invocation, and give its exact
-   identifier.
-4. When one match is known and no other inspected source registers the same
-   name, read its complete `SKILL.md` and the resources selected by its
-   instructions, then continue the original task if its invocation policy
-   permits. An inaccessible source does not turn a known match into an absence
-   or require speculation about hidden duplicates. The resolved Skill remains
-   subject to the normal instruction hierarchy and does not expand the user's
-   authorization.
+3. Keep existence, enablement, and invocation eligibility separate. Check the
+   current Codex Skill configuration for the resolved path. When its
+   `[[skills.config]]` entry sets `enabled = false`, report that the Skill is
+   present but disabled, and do not load its body or follow its instructions.
+   For each enabled match, inspect its adjacent `agents/openai.yaml` when
+   present before establishing invocation eligibility. An explicit-only
+   `policy.allow_implicit_invocation: false` value does not make a Skill absent.
+   A user prompt that directly invokes the Skill can satisfy that policy; a
+   reference from another active Skill triggers this resolution check but is
+   not direct user invocation. When the current invocation does not satisfy
+   the resolved Skill's policy, report that the Skill was found but requires
+   direct user invocation, and give its exact identifier.
+4. When one match is known, no other inspected source registers the same name,
+   and step 3 establishes that it is enabled and invocation-eligible, read its
+   complete `SKILL.md` and the resources selected by its instructions, then
+   continue the original task. An inaccessible source does not turn a known
+   match into an absence or require speculation about hidden duplicates. The
+   resolved Skill remains subject to the normal instruction hierarchy and does
+   not expand the user's authorization.
 5. When multiple known Skills register the exact identifier, report every
    match and its invocation eligibility before selecting one. Do not merge them
    or choose silently; request the disambiguation needed to select one.
@@ -56,6 +65,7 @@ came from the user, an active Skill, or another instruction.
 ## Completion criteria
 
 Finish only when the invoked identifier has been resolved to one eligible
-Skill, identified as present but requiring direct invocation, disambiguated by
-the user, reported absent after complete inspection, or reported unresolved
-without an absence claim because an applicable source could not be inspected.
+Skill, identified as present but disabled or requiring direct invocation,
+disambiguated by the user, reported absent after complete inspection, or
+reported unresolved without an absence claim because an applicable source
+could not be inspected.

--- a/skills/resolve-invoked-codex-skill/SKILL.md
+++ b/skills/resolve-invoked-codex-skill/SKILL.md
@@ -21,23 +21,58 @@ came from the user, an active Skill, or another instruction.
      through the repository root;
    - the user `.agents/skills` directory;
    - the administrator Skill directory;
-   - installed-plugin and bundled-system Skills through client-provided Skill
-     inventory when they are not represented by a documented filesystem path.
+   - installed-plugin and bundled-system Skills through Codex's plugin state
+     and resolved plugin paths, as well as client-provided Skill inventory.
 
    Also inspect the current `[[skills.config]]` entries as path evidence. When
    an entry identifies a path not found through another source, inspect only
    enough frontmatter at that path to match its registered name; do not load a
    disabled Skill's body as instructions.
 
-   Match the registered `name` in each `SKILL.md`, not only its directory name.
-   For a namespaced identifier, use the namespace to restrict the plugin and
-   match its Skill name within that package. Search these documented sources
-   rather than arbitrary filesystem locations.
+   Treat omission from the initial Skill catalog as incomplete evidence. For a
+   direct `$name` invocation, or a selection made through `/skills`, use the
+   client's explicit Skill resolution result when it is available. When Codex
+   CLI is available, use `codex plugin list --available --json` to enumerate
+   installed and available plugins and obtain their plugin identifier,
+   installation and enabled state, version, and resolved source path. For each
+   installed plugin, locate its manifest-declared Skill directory or default
+   `skills/` directory. Inspect that directory in the installed cache copy when
+   present and otherwise in the resolved plugin path reported by Codex. For an
+   uninstalled plugin, inspect only enough frontmatter under its resolved source
+   path to establish an exact match; do not load the Skill body as instructions
+   or treat it as invocable.
 
-3. Keep existence, enablement, and invocation eligibility separate. Check the
-   current Codex Skill configuration for the resolved path. When its
-   `[[skills.config]]` entry sets `enabled = false`, report that the Skill is
-   present but disabled, and do not load its body or follow its instructions.
+   When the JSON listing is unavailable but the marketplace command exists,
+   use `codex plugin marketplace list` to obtain every resolved marketplace
+   root. Otherwise inspect the repository, legacy-compatible, and personal
+   marketplace files described in
+   [OpenAI's plugin documentation](https://developers.openai.com/plugins/build/plugins/#how-local-marketplaces-work).
+   Resolve each local object-form `source.path` or plain-string `source`
+   relative to its marketplace root, and also inspect the documented installed
+   cache under
+   `~/.codex/plugins/cache/<marketplace>/<plugin>/<version>/`. Marketplace
+   paths are configurable examples, not fixed plugin locations. A marketplace
+   entry alone proves availability for installation, not installation; when
+   installation state or a resolved plugin path cannot be established, record
+   that source as an inspection limitation instead of claiming absence.
+
+   Match the registered `name` in each `SKILL.md`, not only its directory name.
+   For a namespaced identifier, use the namespace to restrict the
+   client-reported plugin or plugin identifier, then match its Skill name
+   within that package. Search these documented sources rather than arbitrary
+   filesystem locations.
+
+3. Keep existence, installation, enablement, and invocation eligibility
+   separate. When an exact match belongs to a plugin that is not installed,
+   report that state and do not load the Skill body as instructions. For an
+   installed plugin Skill, honor the plugin-level enabled state reported by
+   Codex or, when that state is unavailable, stored in
+   `~/.codex/config.toml`. When the plugin is disabled, inspect only enough
+   frontmatter to establish the exact match, report that the Skill is present
+   but its plugin is disabled, and do not load its body. Then check the current
+   Codex Skill configuration for the resolved path. When its `[[skills.config]]`
+   entry sets `enabled = false`, report that the Skill is present but disabled,
+   and do not load its body or follow its instructions.
    For each enabled match, inspect its adjacent `agents/openai.yaml` when
    present before establishing invocation eligibility. An explicit-only
    `policy.allow_implicit_invocation: false` value does not make a Skill absent.
@@ -65,7 +100,7 @@ came from the user, an active Skill, or another instruction.
 ## Completion criteria
 
 Finish only when the invoked identifier has been resolved to one eligible
-Skill, identified as present but disabled or requiring direct invocation,
-disambiguated by the user, reported absent after complete inspection, or
-reported unresolved without an absence claim because an applicable source
-could not be inspected.
+Skill; identified as present but uninstalled, disabled, or requiring direct
+invocation; disambiguated by the user; reported absent after complete
+inspection; or reported unresolved without an absence claim because an
+applicable source could not be inspected.

--- a/skills/resolve-invoked-codex-skill/SKILL.md
+++ b/skills/resolve-invoked-codex-skill/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: resolve-invoked-codex-skill
+description: Use only in Codex whenever a specific Skill is invoked or required by exact name, its instructions are unavailable in the current context, and the Agent would otherwise state that the Skill is absent or unavailable.
+---
+
+# Resolve an invoked Codex Skill
+
+Resolve the exact Skill against Codex's documented Skill sources before
+reporting that it is unavailable. Apply the same check whether the invocation
+came from the user, an active Skill, or another instruction.
+
+1. Derive the exact registered identifier from the invocation. Treat a leading
+   `$` or `/` that clearly denotes a Skill as invocation syntax rather than part
+   of its name, and preserve any namespace. Check the current Skill catalog and
+   already loaded Skill paths first. Do not infer absence from the bounded
+   initial catalog because Codex may omit entries when many Skills are
+   installed.
+2. If the exact identifier is not available there, inspect every applicable
+   Codex Skill source documented in
+   [OpenAI's Codex Skill documentation](https://developers.openai.com/codex/skills/):
+   - repository `.agents/skills` directories from the active working directory
+     through the repository root;
+   - the user `.agents/skills` directory;
+   - the administrator Skill directory;
+   - installed-plugin and bundled-system Skills through client-provided Skill
+     inventory when they are not represented by a documented filesystem path.
+
+   Match the registered `name` in each `SKILL.md`, not only its directory name.
+   For a namespaced identifier, use the namespace to restrict the plugin and
+   match its Skill name within that package. Search these documented sources
+   rather than arbitrary filesystem locations.
+
+3. Keep existence separate from invocation eligibility. An explicit-only
+   policy does not make a Skill absent. A user prompt that directly invokes the
+   Skill can satisfy that policy; a reference from another active Skill triggers
+   this resolution check but is not direct user invocation. When the current
+   invocation does not satisfy the resolved Skill's policy, report that the
+   Skill was found but requires direct user invocation, and give its exact
+   identifier.
+4. When one match is known and no other inspected source registers the same
+   name, read its complete `SKILL.md` and the resources selected by its
+   instructions, then continue the original task if its invocation policy
+   permits. An inaccessible source does not turn a known match into an absence
+   or require speculation about hidden duplicates. The resolved Skill remains
+   subject to the normal instruction hierarchy and does not expand the user's
+   authorization.
+5. When multiple known Skills register the exact identifier, report every
+   match and its invocation eligibility before selecting one. Do not merge them
+   or choose silently; request the disambiguation needed to select one.
+6. State that the Skill is absent only after no exact match remains and every
+   applicable documented source was inspected. When a source cannot be
+   inspected, report the Skill as unresolved in the checked sources rather than
+   absent. In either case, name the sources checked and every inspection
+   limitation so the conclusion does not exceed the evidence.
+
+## Completion criteria
+
+Finish only when the invoked identifier has been resolved to one eligible
+Skill, identified as present but requiring direct invocation, disambiguated by
+the user, reported absent after complete inspection, or reported unresolved
+without an absence claim because an applicable source could not be inspected.


### PR DESCRIPTION
## Summary

- offer a knowledge-base contribution proposal when a completed task yields qualified reusable learning
- prepare detailed, evidence-backed contribution content only after the user accepts the offer
- resolve an invoked Codex Skill against documented sources before reporting it absent

## Validation

- pnpm check
- Skill structural validation
- behavioral forward tests for proposal gating and Codex Skill resolution
- two-axis Standards and Spec review