### PR TITLE
Add image-to-video prompt design Skill

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.29-4",
+  "version": "2026.8.29-5",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/references/generative-media/natural-language-prompt-format.md
+++ b/references/generative-media/natural-language-prompt-format.md
@@ -1,0 +1,20 @@
+# Natural-language prompt format
+
+Use this reference when a Skill renders a copyable natural-language prompt for
+a generative visual model.
+
+Follow the user's language unless the user requests another language. Place the
+copyable prompt inside one plain-text fenced block as continuous multi-paragraph
+prose. Use complete sentences and paragraph breaks rather than Markdown
+headings, labeled fields, numbered or bulleted lists, tables, JSON, YAML, XML,
+or comma-separated keyword and tag strings.
+
+Give each paragraph one coherent responsibility. Let the consuming workflow
+determine the useful information order, and merge, split, reorder, extend, or
+omit paragraphs when that makes the requested result clearer. This is a prose
+contract, not a fixed paragraph count or required content schema.
+
+Keep requirement analysis, diagnoses, assumptions, and usage explanations
+outside the copyable prompt. Make the prompt self-contained with only the model
+inputs declared by the consuming workflow; do not rely on earlier conversation
+or undeclared artifacts.

--- a/skills/design-image-generation-prompts/SKILL.md
+++ b/skills/design-image-generation-prompts/SKILL.md
@@ -104,10 +104,12 @@ than defining its limits.
 
 ## Construct and deliver the prompt
 
-Read [Prompt construction](references/prompt-construction.md) after the visual
-requirements are settled. Use it to translate the final design into a
-self-contained, static, natural-language prompt and to render the prompt
-package.
+Read
+[Natural-language prompt format](../../references/generative-media/natural-language-prompt-format.md)
+and [Prompt construction](references/prompt-construction.md) after the visual
+requirements are settled. Apply the shared format while using the local
+reference to translate the final design into a static image prompt and render
+the prompt package.
 
 Before finishing, verify that:
 
@@ -122,8 +124,8 @@ Before finishing, verify that:
 - multiple people have unambiguous identities, actions, interactions, and
   spatial relationships;
 - user constraints remain authoritative over inferred aesthetic improvements;
-- the copyable prompt is continuous multi-paragraph prose rather than headings,
-  labeled fields, a list, a data structure, or a keyword string;
+- the copyable prompt follows the
+  [shared natural-language prompt format](../../references/generative-media/natural-language-prompt-format.md);
 - the prompt is coherent, self-contained, model-independent, and free of
   provider-specific syntax or parameters; and
 - the response contains the prompt package without invoking an image-generation

--- a/skills/design-image-generation-prompts/references/prompt-construction.md
+++ b/skills/design-image-generation-prompts/references/prompt-construction.md
@@ -28,20 +28,12 @@ moving camera. A prompt can depict a runner in mid-stride; it cannot ask a still
 image to show the runner beginning, accelerating, turning a corner, and then
 stopping.
 
-## Format the prompt as prose
+## Organize the image prompt
 
-Write the copyable prompt as continuous multi-paragraph natural language inside
-one plain-text fenced block. Use complete sentences and paragraph breaks, not
-Markdown headings, labeled fields such as `Subject:` or `Lighting:`, numbered or
-bulleted lists, tables, JSON, YAML, XML, or comma-separated keyword and tag
-strings.
-
-Give each paragraph a coherent visual responsibility. A useful progression is
-to establish the whole frame, resolve its people and action, place them in the
-setting and composition, describe the selected rendering language, and finish
-with important invariants or exclusions. This is a reading flow rather than a
-fixed paragraph count or required template: merge, split, reorder, extend, or
-omit paragraphs when the image is clearer another way.
+A useful image-specific progression is to establish the whole frame, resolve
+its people and action, place them in the setting and composition, describe the
+selected rendering language, and finish with important invariants or
+exclusions.
 
 Express creation instructions, image roles, edit operations, static target
 states, and invariants as complete sentences in the paragraphs that own those
@@ -108,8 +100,7 @@ write a complete replacement prompt rather than a conversational patch such as
 
 ## Render the prompt package
 
-Follow the user's language unless they request another language. Include only
-the sections that carry information for the current request:
+Include only the sections that carry information for the current request:
 
 1. **Requirement summary:** use for a complex result or material assumptions.
 2. **Image handling:** use when images are involved. Distinguish model inputs
@@ -119,17 +110,14 @@ the sections that carry information for the current request:
    evidence for the revision. Explain the material cause briefly outside the
    prompt.
 4. **Final prompt:** always include one canonical, complete prompt using the
-   prose format above. It must stand on its own with only the declared
-   model-input images. Add complete alternative prompts only when the user asks
-   for variants or confirms that a materially different visual direction should
-   remain open; do not generate variants mechanically.
+   required natural-language format. Add complete alternative prompts only when
+   the user asks for variants or confirms that a materially different visual
+   direction should remain open; do not generate variants mechanically.
 
 The numbered sections describe the available output components, not a form that
-must always contain four headings. Add a short, task-specific note outside the
-prompt when it materially helps the user apply the package; keep analysis and
-explanation out of the copyable prompt itself.
+must always contain four headings. Add a short, task-specific note when it
+materially helps the user apply the package.
 
-Review the final prompt as if the image model receives only that text and the
-declared model-input images. It is complete when the intended still frame,
-people, relationships, rendering, and constraints remain understandable
-without the earlier conversation or any analysis-only reference.
+The image prompt is complete when the intended still frame, people,
+relationships, rendering, and constraints are explicit from the final prompt
+and declared model-input images, without any analysis-only reference.

--- a/skills/design-image-to-video-prompts/SKILL.md
+++ b/skills/design-image-to-video-prompts/SKILL.md
@@ -68,10 +68,11 @@ the choice, make the quality-oriented decision and surface it in the
 requirement summary.
 
 Fill low-impact gaps coherently. Surface material assumptions, and ask when
-hard constraints conflict. For a simple, low-ambiguity motion plan, proceed
-without a separate confirmation turn. Before composing a materially complex
-plan, present the current understanding and wait for confirmation unless the
-user delegated the remaining choices.
+hard constraints conflict. After camera behavior is settled as required above,
+proceed with a simple, low-ambiguity motion plan without a separate whole-plan
+confirmation turn. Before composing a materially complex plan, present the
+current understanding and wait for confirmation unless the user delegated the
+remaining choices.
 
 ## Construct and deliver the prompt
 

--- a/skills/design-image-to-video-prompts/SKILL.md
+++ b/skills/design-image-to-video-prompts/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: design-image-to-video-prompts
+description: Use when the user wants to design a detailed, model-independent natural-language prompt for a people-focused continuous video generated from one required first-frame image, either from a new motion idea or by replacing an earlier prompt after describing how its generated result failed, with optional integrated audio.
+---
+
+# Design image-to-video prompts
+
+Produce a prompt package that another video model can use with one supplied
+first-frame image to generate one continuous, people-focused shot. Finish with
+the prompt package; leave video generation, model selection, provider
+parameters, provider acceptance, and first-frame repair to the caller.
+
+## Validate the request and first frame
+
+1. Require exactly one first-frame image that the user will supply to the video
+   model with the final prompt. This Skill does not own text-only video
+   generation, multiple model-input images, shot lists, edits to the first
+   frame, or multi-shot sequences.
+2. Inspect the accessible first frame instead of asking the user to report
+   visible facts. When it cannot be inspected, ask the user to reattach it and
+   stop prompt design until it is available.
+3. Confirm that one or more people are the video's visual focus and that the
+   requested result can remain one continuous shot. Treat photorealistic,
+   anime, painterly, 3D, and other visual media as open possibilities rather
+   than an exhaustive style taxonomy.
+
+## Establish the generation contract
+
+1. Record whether the request is a new prompt or a revision of an earlier
+   attempt. For a revision, require the earlier prompt and the user's textual
+   description of the failure; the failed video itself is not an available
+   input. Read [Prompt-revision diagnosis](references/prompt-revision.md) before
+   planning the replacement prompt.
+2. Require a target duration. Use an already supplied duration; otherwise ask
+   the user how many seconds the video should last. Do not substitute a current
+   provider's supported duration range for the user's decision.
+3. Ask whether the target model should generate video only or generate video
+   and audio together when the request does not already say. For integrated
+   audio, read
+   [Integrated-audio requirements](references/integrated-audio.md). Skip audio
+   research entirely for a video-only request.
+
+## Research the motion plan
+
+Read [Motion requirements](references/motion-requirements.md) after the first
+frame, duration, and audio mode are known. Apply its decision lenses as an open
+attention set rather than a questionnaire or exhaustive motion taxonomy.
+
+Build a decision frontier from the request and visible first-frame evidence. In
+each round, ask every currently answerable question whose unresolved answer
+would materially change the motion, timing, camera, continuity, end state, or
+integrated audio. Give a recommended answer for each question. Do not repeat a
+settled question, ask the user for visible facts you can inspect, or turn the
+reference's examples into required fields.
+
+Evaluate whether the requested actions fit the confirmed duration. When they do
+not, explain the conflict and recommend concrete choices such as extending the
+duration, simplifying or prioritizing actions, converting an event into
+supporting motion, or moving separate events into separate clips. Wait for the
+user's choice instead of silently accelerating, deleting, or combining primary
+events.
+
+Recommend a camera behavior from the first-frame composition, subject motion,
+duration, continuity risk, and desired effect. Ask the user to accept it or
+choose another plan. When the user already selected a camera behavior, verify
+its compatibility instead of asking again. When the user explicitly delegates
+the choice, make the quality-oriented decision and surface it in the
+requirement summary.
+
+Fill low-impact gaps coherently. Surface material assumptions, and ask when
+hard constraints conflict. For a simple, low-ambiguity motion plan, proceed
+without a separate confirmation turn. Before composing a materially complex
+plan, present the current understanding and wait for confirmation unless the
+user delegated the remaining choices.
+
+## Construct and deliver the prompt
+
+Read
+[Natural-language prompt format](../../references/generative-media/natural-language-prompt-format.md)
+and [Prompt construction](references/prompt-construction.md) after the motion,
+camera, continuity, end state, and applicable audio requirements are settled.
+Apply the shared format while using the local reference to express temporal
+structure and render the video prompt package.
+
+Before finishing, verify that:
+
+- the response identifies the one first-frame image as a required model input;
+- the confirmed duration appears in both the requirement summary and the final
+  prompt;
+- the primary action and any supporting motion fit that duration;
+- every important action has an unambiguous actor, direction, speed, magnitude,
+  temporal relationship, and end state when those properties matter;
+- camera behavior was accepted, supplied by the user, or explicitly delegated;
+- the prompt begins from the visible first-frame state without redundantly
+  redescribing it;
+- continuity requirements protect only the identity, design, setting, style,
+  or physical relationships that materially need protection;
+- the prompt describes one continuous shot without cuts, time jumps, or hidden
+  additional scenes;
+- continuity and exclusion needs are expressed as positive target states
+  without a dedicated negative-prompt field or list;
+- integrated audio appears only when selected and has a coherent relationship
+  to the visual timing;
+- the copyable prompt follows the
+  [shared natural-language prompt format](../../references/generative-media/natural-language-prompt-format.md);
+- the prompt is self-contained, model-independent, and free of provider-specific
+  syntax or parameters; and
+- the response contains the prompt package without invoking a video-generation
+  tool.

--- a/skills/design-image-to-video-prompts/SKILL.md
+++ b/skills/design-image-to-video-prompts/SKILL.md
@@ -58,11 +58,12 @@ you can inspect, or turn the reference's examples into required fields.
 Evaluate whether the requested actions fit the confirmed duration. When they do
 not, explain the conflict and recommend concrete choices such as extending the
 duration, simplifying or prioritizing actions, converting an event into
-supporting motion, or moving other events into later clips. Treat later clips
-as a workflow boundary: agree which event remains in the current continuous
-shot, produce only that prompt, and explain that each later clip needs a new
-invocation after its first-frame image exists. Wait for the user's choice
-instead of silently accelerating, deleting, or combining primary events.
+supporting motion, or moving other events into later clips. Wait for the user's
+choice instead of silently accelerating, deleting, or combining primary
+events. When the user selects later clips, agree which event remains in the
+current continuous shot, continue the ordinary camera and construction path
+for that one shot, produce only its prompt, and explain that each later clip
+needs a new invocation after its first-frame image exists.
 
 Recommend a camera behavior from the first-frame composition, subject motion,
 duration, continuity risk, and desired effect. Ask the user to accept it or

--- a/skills/design-image-to-video-prompts/SKILL.md
+++ b/skills/design-image-to-video-prompts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-image-to-video-prompts
-description: Use when the user wants to design a detailed, model-independent natural-language prompt for a people-focused continuous video generated from one required first-frame image, either from a new motion idea or by replacing an earlier prompt after describing how its generated result failed, with optional integrated audio.
+description: Use when the user wants an image-to-video prompt for a people-focused continuous video generated from one required first-frame image, either by designing a detailed, model-independent natural-language prompt from a new motion idea or by replacing an earlier prompt after describing how its generated result failed, with optional integrated audio.
 ---
 
 # Design image-to-video prompts

--- a/skills/design-image-to-video-prompts/SKILL.md
+++ b/skills/design-image-to-video-prompts/SKILL.md
@@ -51,9 +51,9 @@ attention set rather than a questionnaire or exhaustive motion taxonomy.
 Build a decision frontier from the request and visible first-frame evidence. In
 each round, ask every currently answerable question whose unresolved answer
 would materially change the motion, timing, camera, continuity, end state, or
-integrated audio. Give a recommended answer for each question. Do not repeat a
-settled question, ask the user for visible facts you can inspect, or turn the
-reference's examples into required fields.
+integrated audio when that mode was selected. Give a recommended answer for
+each question. Do not repeat a settled question, ask the user for visible facts
+you can inspect, or turn the reference's examples into required fields.
 
 Evaluate whether the requested actions fit the confirmed duration. When they do
 not, explain the conflict and recommend concrete choices such as extending the

--- a/skills/design-image-to-video-prompts/SKILL.md
+++ b/skills/design-image-to-video-prompts/SKILL.md
@@ -29,8 +29,10 @@ parameters, provider acceptance, and first-frame repair to the caller.
 1. Record whether the request is a new prompt or a revision of an earlier
    attempt. For a revision, require the earlier prompt and the user's textual
    description of the failure; the failed video itself is not an available
-   input. Read [Prompt-revision diagnosis](references/prompt-revision.md) before
-   planning the replacement prompt.
+   input. If either required artifact is missing, ask the user to provide it and
+   stop replacement design until it is available. Read
+   [Prompt-revision diagnosis](references/prompt-revision.md) before planning
+   the replacement prompt.
 2. Require a target duration. Use an already supplied duration; otherwise ask
    the user how many seconds the video should last. Do not substitute a current
    provider's supported duration range for the user's decision.

--- a/skills/design-image-to-video-prompts/SKILL.md
+++ b/skills/design-image-to-video-prompts/SKILL.md
@@ -58,9 +58,11 @@ you can inspect, or turn the reference's examples into required fields.
 Evaluate whether the requested actions fit the confirmed duration. When they do
 not, explain the conflict and recommend concrete choices such as extending the
 duration, simplifying or prioritizing actions, converting an event into
-supporting motion, or moving separate events into separate clips. Wait for the
-user's choice instead of silently accelerating, deleting, or combining primary
-events.
+supporting motion, or moving other events into later clips. Treat later clips
+as a workflow boundary: agree which event remains in the current continuous
+shot, produce only that prompt, and explain that each later clip needs a new
+invocation after its first-frame image exists. Wait for the user's choice
+instead of silently accelerating, deleting, or combining primary events.
 
 Recommend a camera behavior from the first-frame composition, subject motion,
 duration, continuity risk, and desired effect. Ask the user to accept it or

--- a/skills/design-image-to-video-prompts/references/integrated-audio.md
+++ b/skills/design-image-to-video-prompts/references/integrated-audio.md
@@ -1,0 +1,26 @@
+# Integrated-audio requirements
+
+Use this reference only when the user intends the target video model to generate
+the video's audio together with its visuals. Keep audio absent from a
+video-only prompt.
+
+Determine which sounds materially belong to the continuous shot. Relevant
+possibilities include dialogue, action sound effects, ambient sound, music,
+off-screen sources, spatial placement, and synchronization with visible events.
+This is an open attention set rather than a required audio schema.
+
+For dialogue, establish the speaker, exact words, language, delivery, and timing
+when they matter. Quote exact spoken text verbatim in the final prompt. Keep the
+amount of speech compatible with the confirmed duration and the visible mouth
+movement; ask the user to shorten dialogue or extend the shot when it cannot fit
+naturally.
+
+Connect action sounds to their visible causes and timing. Describe ambient
+sound and music only to the degree that they shape this shot, and distinguish
+sound originating inside the scene from off-screen or non-diegetic sound when
+that relationship matters. Avoid provider-specific audio syntax or assumptions
+about separate tracks.
+
+The audio plan is ready when every important sound has a clear source, timing,
+and relationship to the visible motion, and the combined visual and audio event
+density remains feasible within the confirmed duration.

--- a/skills/design-image-to-video-prompts/references/motion-requirements.md
+++ b/skills/design-image-to-video-prompts/references/motion-requirements.md
@@ -1,0 +1,95 @@
+# Motion requirements
+
+Use these decision lenses to turn the supplied first frame and target duration
+into one feasible continuous shot. They are an open set of attention points,
+not a questionnaire, a required schema, or a limit on unfamiliar motion that a
+request may need.
+
+## Read the first frame as the initial state
+
+Treat the first frame as authoritative for the video's initial people, poses,
+objects, setting, composition, camera position, lighting, and visual medium.
+Identify the parts that must move, the parts whose continuity is important, and
+the visual cues that constrain plausible motion.
+
+Check whether visible blur, compression artifacts, malformed details, unclear
+contact, an extreme pose, directional effects, or another feature could become
+more prominent during animation or conflict with the requested motion. Ask the
+user to replace the frame or revise the motion only when the conflict blocks a
+coherent result. Otherwise report the risk without taking ownership of image
+repair.
+
+## Fit motion to duration
+
+Select one primary action or change that the shot can communicate clearly. Add
+secondary movement when it supports that event rather than competing with it.
+Direction, speed, magnitude, acceleration, pauses, and follow-through matter
+when changing them would alter the result.
+
+Use the confirmed duration as an action budget. A simple motion may need only a
+speed and end state. Several ordered actions need enough time to remain legible
+and may require approximate phases. Several simultaneous motions should share
+the same phase rather than becoming an artificial sequence.
+
+When the action budget does not fit, identify which events are primary and
+which are supporting. Recommend a longer duration, fewer events, simpler
+movement, or separate clips. Do not conceal an infeasible plan by compressing
+every event into abrupt motion.
+
+## Coordinate the moving layers
+
+Inspect every motion layer relevant to the shot. Examples include people,
+facial expression and gaze, interactive objects, hair and clothing, vehicles,
+liquids, particles, foliage, weather, reflections, lighting, background layers,
+and the camera. Introduce other layers when they control the requested result;
+omit examples that have no effect on it.
+
+Keep the layers causally and physically coherent. Supporting movement should
+respond to the primary action, forces, environment, or camera rather than
+moving independently without a visual reason. For multiple people, resolve who
+performs each action, who or what receives it, how contact changes, and whether
+their motions are sequential or simultaneous.
+
+## Choose the camera behavior
+
+Select a camera plan that begins from the first frame and remains compatible
+with the subject's path, available space, duration, and continuity risk. A
+stable fixed camera or one simple movement is usually more controllable than
+several combined moves, but use a more complex plan when the requested shot
+genuinely requires it.
+
+Consider whether the camera remains fixed, pans, tilts, pushes, pulls, tracks,
+orbits, changes height, uses handheld movement, or follows another coherent
+path. These are examples, not a closed camera vocabulary. Specify direction,
+speed, magnitude, subject relationship, and stopping point when they matter.
+
+## Preserve the selected medium
+
+Use the same temporal and camera reasoning across visual media, then describe
+motion in the language the first frame requires.
+
+For photorealistic footage, relevant considerations may include balance,
+natural body mechanics, breathing, inertia, cloth and hair response, physical
+contact, lighting, reflections, focus, exposure, and plausible camera motion.
+
+For anime-style animation, relevant considerations may include stable character
+design, line and cel-shading continuity, readable key poses, controlled timing,
+hair and clothing follow-through, background-layer motion, 2D parallax, and
+intentional animation emphasis.
+
+These examples do not require the prompt to restate a style already visible in
+the first frame. Add or omit medium-specific decisions according to the actual
+shot.
+
+## Define the end state
+
+Settle what the subject, camera, environment, and applicable sound are doing at
+the end of the confirmed duration. The shot may hold on a completed pose, reach
+a target framing, let supporting motion settle, move a person out of frame, or
+return near the first frame for a loop. These are illustrative outcomes rather
+than a closed set.
+
+The motion plan is ready when the Agent can explain how one continuous shot
+starts from the supplied frame, develops within the duration, and arrives at a
+clear end state without an unresolved high-impact timing, camera, continuity,
+or interaction decision.

--- a/skills/design-image-to-video-prompts/references/motion-requirements.md
+++ b/skills/design-image-to-video-prompts/references/motion-requirements.md
@@ -33,7 +33,7 @@ the same phase rather than becoming an artificial sequence.
 
 When the action budget does not fit, identify which events are primary and
 which are supporting. Recommend a longer duration, fewer events, simpler
-movement, or separate clips. Do not conceal an infeasible plan by compressing
+movement, or later clips. Do not conceal an infeasible plan by compressing
 every event into abrupt motion.
 
 ## Coordinate the moving layers

--- a/skills/design-image-to-video-prompts/references/prompt-construction.md
+++ b/skills/design-image-to-video-prompts/references/prompt-construction.md
@@ -1,0 +1,81 @@
+# Prompt construction
+
+Turn the settled motion plan into a model-independent natural-language prompt
+for one continuous video generated from the supplied first frame.
+
+## Let the first frame describe appearance
+
+Use the first frame as the visual source of truth. Focus the prompt on what
+changes over time instead of routinely restating people, clothing, setting,
+composition, lighting, or style that the model can already see. Restate a
+visible element only when it moves, transforms, participates in an interaction,
+conflicts with the desired motion, or needs explicit continuity protection.
+
+Open by naming the confirmed duration and the continuous relationship to the
+input, such as “Generate a continuous six-second video beginning exactly from
+the supplied first frame.” Express provider controls as ordinary visual or
+temporal intent rather than parameter names or command syntax.
+
+## Express time in prose
+
+For one simple action, state its direction, speed, magnitude, development, and
+end state without inventing time segments. For several ordered actions, use
+natural phases such as “at the start,” “then,” and “by the end,” or embed
+approximate seconds in complete sentences when the confirmed duration benefits
+from tighter allocation.
+
+Describe simultaneous supporting motion beside the primary action it supports.
+Do not turn hair, clothing, weather, reflections, or other secondary movement
+into separate sequential events unless they genuinely change at different
+times.
+
+## Organize the continuous video prompt
+
+A useful video-specific progression may establish the first-frame relationship
+and duration, develop the primary action, coordinate camera and supporting
+motion, define continuity and the end state, and describe integrated audio when
+selected.
+
+Keep timing inside the prose. Do not turn the prompt into a timeline, shot list,
+or multi-shot screenplay.
+
+## Control camera and continuity positively
+
+Describe the selected camera behavior explicitly. Omitting camera direction is
+not a reliable way to request a fixed camera. State the desired result
+positively, such as a stable locked camera, one uninterrupted tracking move, or
+a continuous shot that keeps the subject centered.
+
+Protect only the continuity that materially risks drifting during the planned
+motion. Express the desired stable state directly: the same character identity,
+unchanged clothing, consistent line art and cel shading, stable background
+geometry, continuous lighting, or another request-specific invariant. Do not
+append a generic negative-prompt list or a provider-specific negative field.
+
+## Render the prompt package
+
+Include only the output components that carry information for the request:
+
+1. **Requirement summary:** always record the first-frame input, duration,
+   primary action, selected camera behavior, audio mode, and material
+   assumptions.
+2. **Duration and action assessment:** use only when the requested events did
+   not fit and the user selected a revised plan.
+3. **Revision diagnosis:** use only when an earlier prompt and text-described
+   failure informed the replacement.
+4. **Final prompt:** always include one canonical, complete prompt using the
+   required natural-language format.
+5. **Usage note:** always remind the user to supply the first frame and, when
+   the target model exposes a duration control, set it to the confirmed
+   duration.
+
+The requirement summary, final prompt, and usage note are required. Include the
+duration assessment and revision diagnosis only when their conditions apply;
+do not render unused headings. When integrated audio was selected, include its
+settled sound and synchronization requirements in a distinct prose paragraph
+inside the same prompt.
+
+The video prompt is complete when the declared first frame, final prompt, and
+matching duration setting let the model identify one continuous progression,
+the motion and camera remain feasible within the duration, and the end state
+and material continuity requirements are explicit.

--- a/skills/design-image-to-video-prompts/references/prompt-revision.md
+++ b/skills/design-image-to-video-prompts/references/prompt-revision.md
@@ -1,0 +1,24 @@
+# Prompt-revision diagnosis
+
+Use this reference when the user wants to revise an earlier image-to-video
+prompt from a supplied first frame and a textual description of the failed
+result. The Agent cannot observe the failed video and must not present an
+inference as direct visual evidence.
+
+Ask the user to describe what happened, approximately when it happened, and
+what should have happened instead whenever the available report does not
+already establish those facts. Compare that report with the first frame,
+earlier prompt, duration, and intended result.
+
+Possible causes include excessive action density, ambiguous order, unsuitable
+speed or magnitude, missing identity continuity, competing subject and camera
+motion, an unclear end state, redundant first-frame description, unstable
+physical interactions, or mismatched audio timing. Treat these as diagnostic
+starting points rather than an exhaustive failure taxonomy.
+
+Identify the smallest set of prompt decisions that plausibly explains the
+reported symptom. When several materially different causes remain equally
+plausible, ask a targeted question instead of selecting one silently. Explain
+the selected diagnosis with an uncertainty boundary, then use the ordinary
+motion-planning and construction workflow to produce a complete replacement
+prompt rather than a conversational patch.

--- a/skills/design-image-to-video-prompts/references/prompt-revision.md
+++ b/skills/design-image-to-video-prompts/references/prompt-revision.md
@@ -2,8 +2,8 @@
 
 Use this reference when the user wants to revise an earlier image-to-video
 prompt from a supplied first frame and a textual description of the failed
-result. The Agent cannot observe the failed video and must not present an
-inference as direct visual evidence.
+result. The failed video is outside this Skill's accepted inputs. Do not inspect
+an attached failed video or present an inference as direct visual evidence.
 
 Ask the user to describe what happened, approximately when it happened, and
 what should have happened instead whenever the available report does not


### PR DESCRIPTION
## Summary

- add a model-independent Skill for designing people-focused, continuous image-to-video prompts from one required first frame
- research duration-aware action budgets, camera behavior, continuity, end states, optional integrated audio, and text-described failure revisions
- extract the shared natural-language generative-media prompt format and migrate the existing image prompt Skill without changing its image-specific behavior
- bump the primary plugin version to `2026.8.29-5`

## Validation

- `pnpm check`
- `python3 /Users/soulike/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/design-image-generation-prompts`
- `python3 /Users/soulike/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/design-image-to-video-prompts`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`
- `git diff --check`
- four fresh-context behavior scenarios: missing-duration intake, complete photorealistic video-only prompt, anime integrated-audio prompt, and failure-driven replacement from textual symptoms
- independent Standards and Spec reviews: no findings