### PR TITLE
Strengthen Skill task modeling and validation

### DIFF
--- a/.agents/skills/maintain-knowledge-base/SKILL.md
+++ b/.agents/skills/maintain-knowledge-base/SKILL.md
@@ -50,11 +50,16 @@ of the change effect, but do not authorize changes to independent behavior.
    [Good development documentation](../../../references/documentation/good-development-documentation.md)
    and apply it throughout the applicable authoring workflow.
 7. Read each affected artifact as a whole together with the routes and
-   consumers needed to judge it. Before editing, design the final artifact set
-   by responsibility, retrieval or invocation timing, consumers, and
+   consumers needed to judge it. Read every applicable artifact workflow named
+   below and complete its analysis up to, but not including, application of a
+   parent-selected operation. Reclassify any material that a branch returns.
+   For mixed material, analyze the Knowledge part first, then the Skill part,
+   then its references.
+8. Using the completed artifact-specific analysis, design the final artifact
+   set by responsibility, retrieval or invocation timing, consumers, and
    maintenance lifecycle rather than by the requested operation or current file
    layout.
-8. For every affected responsibility unit, compare making no change, deleting,
+9. For every affected responsibility unit, compare making no change, deleting,
    rewriting, adding, merging, splitting, and moving the material. Complete this
    comparison before adding content at any location. Do not add by default when
    the material corrects, duplicates, or supersedes existing content; needs a
@@ -64,22 +69,23 @@ of the change effect, but do not authorize changes to independent behavior.
    movement preserves the required outcome with less maintained content and
    whether branch-only detail belongs behind progressive disclosure. Select the
    operation that leaves the smallest complete and coherent current model.
-9. For each Knowledge part, read
-   [`references/maintain-knowledge.md`](references/maintain-knowledge.md) and
-   complete that workflow. For each Skill part, read
-   [`references/maintain-skill.md`](references/maintain-skill.md) and complete
-   that workflow. For each Skill-reference part, read
-   [`references/maintain-skill-reference.md`](references/maintain-skill-reference.md)
-   and complete that workflow. For mixed material, finish the Knowledge branch
-   first, then stabilize the Skill responsibilities before finalizing their
-   references. Maintain other repository-owned explanatory or instructional
-   artifacts directly under the parent quality gate and their governing project
-   standards.
-10. When the final diff changes root `knowledge/**`, `references/**`, or
+10. Resume each applicable artifact workflow and apply the selected operations.
+    For each Knowledge part, use
+    [`references/maintain-knowledge.md`](references/maintain-knowledge.md) and
+    complete that workflow. For each Skill part, use
+    [`references/maintain-skill.md`](references/maintain-skill.md) and complete
+    that workflow. For each Skill-reference part, use
+    [`references/maintain-skill-reference.md`](references/maintain-skill-reference.md)
+    and complete that workflow. For mixed material, finish the Knowledge branch
+    first, then stabilize the Skill responsibilities before finalizing their
+    references. Maintain other repository-owned explanatory or instructional
+    artifacts directly under the parent quality gate and their governing project
+    standards.
+11. When the final diff changes root `knowledge/**`, `references/**`, or
     `skills/**`, follow
     [`references/update-plugin-version.md`](references/update-plugin-version.md)
     after the content stabilizes.
-11. When meaning or structure changed, use a fresh Agent or isolated context for
+12. When meaning or structure changed, use a fresh Agent or isolated context for
     a read-only semantic comparison of the trusted pre-change state, accepted
     requirements, and every final affected artifact. Require the comparison to
     account for every semantic change and verify that retained, moved, split,
@@ -87,7 +93,7 @@ of the change effect, but do not authorize changes to independent behavior.
     point. Resolve every unexplained loss, distortion, duplicate authority, or
     route failure and repeat the comparison after each fix. Treat unavailable
     independent comparison as an incomplete result.
-12. Review the combined result and report the classification, affected
+13. Review the combined result and report the classification, affected
     responsibility units, operations performed, changed routes and consumers,
     generated primary-plugin version when applicable, and mechanical and
     semantic validation performed. Explain a plausible structural alternative

--- a/.agents/skills/maintain-knowledge-base/references/maintain-skill.md
+++ b/.agents/skills/maintain-knowledge-base/references/maintain-skill.md
@@ -54,12 +54,15 @@
    obsolete route and file.
 10. Apply the Skill-reference placement and routing rules in
     [`AGENTS.md`](../../../../AGENTS.md#repository-architecture). For every usage
-    Skill that applies Knowledge, encode working-directory precedence. Keep
-    ordinary installed workflows inside their package boundary and free of
-    dependencies on source-checkout tooling, `.agents/`, private infrastructure,
-    or unguaranteed Skill-to-Skill invocation. A contribution Skill may create
-    an isolated checkout of the canonical source and read `.agents/` there, but
-    must not use the installed plugin as its authoring target.
+    Skill that applies Knowledge, encode working-directory precedence: treat
+    shared Knowledge as supplemental guidance and follow instructions, Skills,
+    requirements, and project-specific information from the Agent's active
+    working directory when they conflict. Keep ordinary installed workflows
+    inside their package boundary and free of dependencies on source-checkout
+    tooling, `.agents/`, private infrastructure, or unguaranteed Skill-to-Skill
+    invocation. A contribution Skill may create an isolated checkout of the
+    canonical source and read `.agents/` there, but must not use the installed
+    plugin as its authoring target.
 11. Run `pnpm check`, `git diff --check`, and every additional validator or
     focused test selected by the changed artifacts. Produce the authoring
     standard's required behavioral evidence in a fresh or isolated context. The

--- a/.agents/skills/maintain-knowledge-base/references/maintain-skill.md
+++ b/.agents/skills/maintain-knowledge-base/references/maintain-skill.md
@@ -9,76 +9,71 @@
      `skills/` directory.
 2. Read
    [Agent Skill authoring](../../../../references/agents/skill-authoring.md) and
-   apply its portability, invocation, bundle-structure, disclosure, and
-   behavioral-validation principles to every affected Skill.
-3. Work only from the Skill parts identified during classification. Return
-   separately classified Skill-reference material to the parent workflow so
-   its consumer set and package boundary are handled by the reference branch.
+   use its four stages as the authoring path: define the real task, assign
+   knowledge and execution responsibilities, write the executable workflow, and
+   prove the behavior. Determine whether the change is material under that
+   reference before selecting the amount of research and evidence.
+3. Establish the real task before preserving or changing the current Skill
+   boundary. Record the professional questions that require research, but do not
+   treat the repository's current contents as a complete domain model.
 4. Test every usage workflow against an unknown downstream project. Discover
    project paths, layouts, domain rules, organization policies, and
    infrastructure from the Agent's active working directory rather than
    hard-coding a particular project. Product, platform, protocol, and
    engineering-domain specificity are valid. Return workflows that cannot be
    made independent of their source project to the parent as neither.
-5. Before adding or changing a repository-authoring or primary-plugin Skill,
-   read [`knowledge/index.md`](../../../../knowledge/index.md). Compare the
-   workflow's decisions and required inputs with every `When to Read`
-   condition, read every matching leaf not already loaded, and search
-   `knowledge/` for concepts the Skill would otherwise explain. Reference
-   applicable canonical Knowledge rather than reproducing it. Return missing
-   material to the parent workflow as mixed only when its reading trigger
-   precedes workflow selection and survives removal of every consuming Skill,
-   then complete the Knowledge branch first.
-6. Search the selected Skill scope for existing workflows with the same or
-   overlapping responsibility. Compare their pre-edit invocation conditions,
-   user-visible outcomes, decisions, privileged effects, failure and completion
-   states, consumers, and maintenance lifecycles. Extend an existing Skill only
-   when it already owns the complete affected responsibility.
-7. Read every file in the affected Skill bundle and every route or consumer
-   needed to understand it. Apply the shared reference's bundle-structure,
-   placement, and progressive-disclosure tests before editing. Return
-   separately selected supporting material to the parent as Skill-reference
-   content, and keep only independently invocable responsibilities as Skills.
-8. Apply the parent-selected disposition to every affected responsibility unit.
-   Rewrite the complete unit and remove superseded steps, exceptions, or
-   completion conditions when behavior changes. Delete no-op or obsolete
-   instructions. Do not preserve old and new behavior as layered qualifications
-   when one current path can express the accepted contract.
-9. Apply the shared reference's split and merge tests when the final design
-   changes the bundle boundary. Do not use file length, step count, or reference
-   count as a structural rule.
-10. For a new Skill, use a lowercase hyphenated, verb-led directory name that
-    matches its frontmatter `name`. When renaming, splitting, merging, moving,
-    or removing a Skill, update every invocation pointer, consumer, manifest or
-    marketplace route, test, prompt, and documentation reference, then remove
-    the obsolete route and file.
-11. Apply the Skill-reference placement and routing rules in
-    [`AGENTS.md`](../../../../AGENTS.md#repository-architecture). Confirm the
-    complete consumer set and package boundary before placing each reference.
-12. For every usage Skill that applies Knowledge, encode working-directory
-    precedence: treat shared Knowledge as supplemental guidance and follow
-    instructions, Skills, requirements, and project-specific information from
-    the Agent's active working directory when they conflict with shared
-    Knowledge.
-13. Keep ordinary usage Skills valid after installation: reference only files
-    inside their plugin package and avoid dependencies on `.agents/`, repository
-    tooling, or Skill-to-Skill invocation. A contribution Skill may use the
-    primary manifest's canonical repository URL to create an isolated source
-    checkout and read authoring instructions from `.agents/` inside that
-    checkout; it must not treat the installed plugin's `.agents/` or files as
-    the authoring target. Keep independent plugins fully self-contained and do
-    not reference root Knowledge or root references.
-14. Run repository formatting and relevant tests. Forward-test representative
-    invocation, decision, reference-selection, failure, and completion paths in
-    a fresh or isolated context when static validation cannot establish them.
-    Compare the original and final bundle so every semantic change is intended
-    and every removed or moved route remains reachable where required.
+5. Read [`knowledge/index.md`](../../../../knowledge/index.md). Compare the task
+   model with every `When to Read` condition, read every matching leaf not
+   already loaded, and search `knowledge/` for subject understanding the Skill
+   would otherwise explain. Then complete the authoring standard's professional
+   research using the loaded Knowledge and any necessary current authoritative
+   sources. Reference applicable canonical Knowledge rather than reproducing it.
+   Return missing independently retrievable understanding to the parent as mixed
+   material, then complete the Knowledge branch before finalizing the Skill.
+6. Search the selected Skill scope for workflows with the same or overlapping
+   task. Compare their invocation conditions, accepted input states,
+   user-visible results, decisions, privileged effects, failure and completion
+   states, consumers, and maintenance lifecycles. Keep one Skill only when it
+   owns one complete task; split or retain separate Skills when those task
+   boundaries differ even if they use the same Knowledge.
+7. Read every file in the affected bundle and every route or consumer needed to
+   understand it. Assign execution to the Skill and separately classified
+   supporting material to the parent Skill-reference branch. Apply the authoring
+   standard's bundle, placement, portability, progressive-disclosure, and
+   split-or-merge rules before editing.
+8. Apply the parent-selected operation to each complete affected responsibility
+   unit. Rewrite the current workflow and remove superseded steps, exceptions,
+   completion conditions, no-op instructions, obsolete routes, and orphaned
+   references. Do not preserve old and new behavior as layered qualifications.
+9. For a new Skill, use a lowercase hyphenated, verb-led directory name that
+   matches its frontmatter `name`. When renaming, splitting, merging, moving, or
+   removing a Skill, update every invocation pointer, consumer, manifest or
+   marketplace route, test, prompt, and documentation reference, then remove the
+   obsolete route and file.
+10. Apply the Skill-reference placement and routing rules in
+    [`AGENTS.md`](../../../../AGENTS.md#repository-architecture). For every usage
+    Skill that applies Knowledge, encode working-directory precedence. Keep
+    ordinary installed workflows inside their package boundary and free of
+    dependencies on source-checkout tooling, `.agents/`, private infrastructure,
+    or unguaranteed Skill-to-Skill invocation. A contribution Skill may create
+    an isolated checkout of the canonical source and read `.agents/` there, but
+    must not use the installed plugin as its authoring target.
+11. Run `pnpm check`, `git diff --check`, and every additional validator or
+    focused test selected by the changed artifacts. Produce the authoring
+    standard's required behavioral evidence in a fresh or isolated context. The
+    parent workflow owns the single independent semantic comparison; do not run
+    a duplicate here or disclose the author's conclusions to its evaluator.
+12. Report the authoring standard's design and behavioral evidence. Identify a
+    mechanical change explicitly when the reduced evidence path applies, and
+    disclose unresolved limitations.
 
-Finish only when the Skill remains in the correct audience scope, preserves
-downstream-project independence when user-facing, and has one task-facing
-entrypoint for each independently invocable responsibility. Its main file must
-contain the complete primary workflow and completion criteria; every reference
-must be selected by an explicit step; every rule must have one authoritative
-copy; every installed-package reference must resolve; and no obsolete route,
-orphan reference, hidden Skill-to-Skill dependency, duplicated workflow, or
-edit-history structure may remain.
+Finish only when the Skill owns a complete real task in the correct audience
+scope, preserves downstream-project independence when user-facing, and has one
+task-facing entrypoint for each independently invocable responsibility. Its
+professional task model must be sufficient for the promised result; its main
+file must contain the complete primary workflow and completion criteria; every
+reference must be selected explicitly; every rule must have one authoritative
+copy; and no obsolete route, orphan reference, hidden Skill dependency,
+duplicated workflow, patch-layered qualification, or edit-history structure may
+remain. New and material behavior must have reviewable design and behavioral
+evidence.

--- a/.agents/skills/maintain-knowledge-base/references/maintain-skill.md
+++ b/.agents/skills/maintain-knowledge-base/references/maintain-skill.md
@@ -9,10 +9,10 @@
      `skills/` directory.
 2. Read
    [Agent Skill authoring](../../../../references/agents/skill-authoring.md) and
-   use its four stages as the authoring path: define the real task, assign
-   knowledge and execution responsibilities, write the executable workflow, and
-   prove the behavior. Determine whether the change is material under that
-   reference before selecting the amount of research and evidence.
+   determine whether the change is material. Before the parent selects an
+   operation, use the reference to define the real task and assign knowledge and
+   execution responsibilities. After selection, resume here to write the
+   executable workflow and prove its behavior.
 3. Establish the real task before preserving or changing the current Skill
    boundary. Record the professional questions that require research, but do not
    treat the repository's current contents as a complete domain model.

--- a/.agents/skills/maintain-knowledge-base/references/maintain-skill.md
+++ b/.agents/skills/maintain-knowledge-base/references/maintain-skill.md
@@ -28,10 +28,12 @@
    would otherwise explain. Then complete the authoring standard's professional
    research using the loaded Knowledge and any necessary current authoritative
    sources. Repository-authoring and primary-plugin Skills reference applicable
-   canonical root Knowledge rather than reproducing it. For an independent
-   plugin, use the comparison only to identify root-owned or out-of-package
-   material: do not reference root files, and return that material to the parent
-   for reclassification or package-ownership reconsideration.
+   canonical root Knowledge rather than reproducing it, and return missing
+   independently retrievable understanding to the parent as mixed material so
+   the Knowledge branch completes first. For an independent plugin, use the
+   comparison only to identify root-owned or out-of-package material: do not
+   reference root files, and return that material to the parent for
+   reclassification or package-ownership reconsideration.
 6. Search the selected Skill scope for workflows with the same or overlapping
    task. Compare their invocation conditions, accepted input states,
    user-visible results, decisions, privileged effects, failure and completion

--- a/.agents/skills/maintain-knowledge-base/references/maintain-skill.md
+++ b/.agents/skills/maintain-knowledge-base/references/maintain-skill.md
@@ -27,9 +27,11 @@
    already loaded, and search `knowledge/` for subject understanding the Skill
    would otherwise explain. Then complete the authoring standard's professional
    research using the loaded Knowledge and any necessary current authoritative
-   sources. Reference applicable canonical Knowledge rather than reproducing it.
-   Return missing independently retrievable understanding to the parent as mixed
-   material, then complete the Knowledge branch before finalizing the Skill.
+   sources. Repository-authoring and primary-plugin Skills reference applicable
+   canonical root Knowledge rather than reproducing it. For an independent
+   plugin, use the comparison only to identify root-owned or out-of-package
+   material: do not reference root files, and return that material to the parent
+   for reclassification or package-ownership reconsideration.
 6. Search the selected Skill scope for workflows with the same or overlapping
    task. Compare their invocation conditions, accepted input states,
    user-visible results, decisions, privileged effects, failure and completion

--- a/.github/scripts/ai-review/prompt.test.ts
+++ b/.github/scripts/ai-review/prompt.test.ts
@@ -56,6 +56,7 @@ test("injects the repository-root guidance routes", async () => {
   assert.deepEqual(linkTargets(prompt), [
     "AGENTS.md",
     ".agents/skills/maintain-knowledge-base/SKILL.md",
+    "references/agents/skill-authoring.md",
     "knowledge/software-testing/test-effectiveness.md",
     "knowledge/software-testing/trustworthy-test-execution.md",
     "knowledge/software-testing/test-execution-cost.md",

--- a/.github/scripts/ai-review/prompts/review.md
+++ b/.github/scripts/ai-review/prompts/review.md
@@ -69,6 +69,12 @@ packaging or delivery, implementation code, repository automation, tests, or
 human-facing documentation. Use that classification to select the applicable
 rules and review dimensions.
 
+For every new or materially changed Skill, inspect the pull-request description
+and its linked evidence for the design and behavioral evidence required by the
+trusted Agent Skill authoring guidance. Independently reconstruct the real user
+task before accepting the author's model or scenarios. Missing applicable
+evidence is an incomplete change even when the proposed prose appears plausible.
+
 ### Trusted repository guidance
 
 {{TRUSTED_GUIDANCE}}
@@ -89,10 +95,16 @@ Review every applicable dimension:
    completeness. Verify evolving claims against current authoritative sources.
 2. **Classification and routing.** Check ownership, retrieval routes,
    lifecycle, package boundaries, and downstream-project independence.
-3. **Agent workflow behavior.** Check invocation conditions, decisions,
+3. **Skill task sufficiency and evidence.** For a new or materially changed
+   Skill, apply the trusted Agent Skill authoring standard to the complete
+   affected task. Independently derive risk-based scenarios and compare them
+   with the supplied design and behavioral evidence. Distinguish a demonstrated
+   content defect from a verification gap; either prevents approval when
+   material.
+4. **Agent workflow behavior.** Check invocation conditions, decisions,
    instruction authority, progressive disclosure, tool use, non-interactive
    behavior, output contracts, and completion criteria.
-4. **Integration and structural quality.** For every affected responsibility
+5. **Integration and structural quality.** For every affected responsibility
    unit, check whether making no change, deletion, rewriting, addition, merging,
    splitting, or movement produces the smallest coherent result. Check for
    superseded wording, duplicated authority, patch-layered qualifications,
@@ -102,7 +114,7 @@ Review every applicable dimension:
    completion criteria belong in `SKILL.md`, and every reference needs an
    explicit selecting step and the package boundary required by the repository
    instructions.
-5. **Packaging and delivery completeness.** Check affected plugin,
+6. **Packaging and delivery completeness.** Check affected plugin,
    marketplace, manifest, versioning, reference, installation, and automation
    paths for stale or missing pieces.
 
@@ -114,6 +126,12 @@ Report only concrete, actionable issues introduced by this pull request. Each
 finding must identify the failure or maintenance harm, explain why it matters,
 and describe a viable correction. Exclude praise, pre-existing problems,
 speculation, and duplicates of existing findings.
+
+When a pull request materially changes a Skill responsibility, review that
+complete affected responsibility against the trusted authoring standard. A
+pre-existing gap is in scope when leaving it in place makes the changed task,
+boundary, or completion model incoherent or insufficient. Do not expand the
+review into unrelated historical deficiencies.
 
 Treat failed integration as a substantive current-change defect when the pull
 request leaves duplicate or conflicting authority, widens an owner to absorb an
@@ -140,6 +158,13 @@ comment limit; every finding must independently meet the standard. The verdict
 is `needs-change` when the current code has at least one `medium` or `high`
 finding, and `approved` otherwise. `low` and `nit` findings remain inline
 comments but do not select `needs-change`.
+
+For missing design or behavioral evidence, anchor the finding to a changed line
+that establishes the affected Skill responsibility. State which evidence is
+missing, why the current behavior cannot be verified, and what the pull-request
+description must supply. Do not present an evidence gap as an observed runtime
+failure. Missing applicable evidence for a new or materially changed Skill is
+at least `medium`.
 
 ## Publish exactly one review
 

--- a/.github/scripts/ai-review/prompts/skills.md
+++ b/.github/scripts/ai-review/prompts/skills.md
@@ -2,6 +2,7 @@ Use these routes from the trusted base revision as review guidance:
 
 - [Repository instructions](AGENTS.md): read and apply the repository's artifact responsibilities, package boundaries, and authoring conventions.
 - [Knowledge-base maintenance workflow](.agents/skills/maintain-knowledge-base/SKILL.md): for changes to Knowledge, Skills, Skill references, or maintained Agent instructions and prompts that govern them, use this workflow and only the references selected by its applicable steps as review criteria.
+- [Agent Skill authoring](references/agents/skill-authoring.md): for a new or materially changed Skill, independently review its real-task model, professional research, responsibility placement, executable workflow, design evidence, and demonstrated behavior.
 - [Test effectiveness](knowledge/software-testing/test-effectiveness.md): use for test coverage, oracles, ownership, doubles, and test value.
 - [Trustworthy test execution](knowledge/software-testing/trustworthy-test-execution.md): use for test collection, selection, skips, fixtures, time, retries, concurrency, platforms, external processes, timeouts, and runner behavior.
 - [Test execution cost](knowledge/software-testing/test-execution-cost.md): use for test runtime and resource-cost claims.

--- a/.github/scripts/content-verification/prompts/verify.md
+++ b/.github/scripts/content-verification/prompts/verify.md
@@ -80,17 +80,30 @@ and continued classification. Check whether ordinary external evolution has
 introduced dependencies that make the content time-sensitive.
 
 For `maintained-agent-content`, review each Skill bundle as one workflow and each
-shared reference once. Check invocation and routing, decisions, tool use,
-failure handling, completion criteria, progressive disclosure, portability,
-package boundaries, and current tool or API assumptions. Reason through
-representative execution branches. Confirm that `SKILL.md` retains the primary
-workflow and completion criteria, every disclosed reference has an explicit
-selecting step, independently invocable responsibilities are not hidden as
-references, and supporting detail that warrants progressive disclosure has not
-accumulated in the main path. Check a shared reference with its consuming
-Skills, while keeping the result owned by the reference target. Require removal
-or consolidation of obsolete, orphaned, duplicated, or edit-history files when
-the complete current bundle no longer justifies them.
+shared reference once. Read
+[Agent Skill authoring](references/agents/skill-authoring.md) as the repository's
+canonical current standard, while keeping this verification prompt
+authoritative. When that reference is itself a target, verify it rather than
+assuming that it is correct.
+
+For each Skill bundle, apply that standard to an independently reconstructed
+current task. Do not require historical pull-request evidence. Use the current
+bundle and current authoritative sources to reason through risk-derived
+invocation, workflow, and output scenarios, including one likely to expose a
+shortcut or omitted professional responsibility. Check invocation and routing,
+decisions, tool use, failure handling, completion criteria, progressive
+disclosure, portability, package boundaries, and current tool or API
+assumptions. Use `verification-failed` when missing or inconclusive evidence
+prevents a trustworthy current-state judgment rather than inventing a defect.
+
+Confirm that `SKILL.md` retains the primary workflow and completion criteria,
+every disclosed reference has an explicit selecting step, independently
+invocable responsibilities are not hidden as references, and supporting detail
+that warrants progressive disclosure has not accumulated in the main path.
+Check a shared reference with its consuming Skills, while keeping the result
+owned by the reference target. Require removal or consolidation of obsolete,
+orphaned, duplicated, patch-layered, or edit-history files when the complete
+current bundle no longer justifies them.
 
 For an `agent-content` target in the `maintained-agent-content` scope, review
 each Agent instruction file and each prompt directory as one maintained unit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,19 @@ Markdown parser and assert against the parsed structure. Treat Markdown source
 text only as parser input; do not infer Markdown structure by matching,
 splitting, or replacing raw text.
 
+## Skill change evidence
+
+A pull request that adds a Skill or materially changes Skill behavior must
+include the design and behavioral evidence required by
+[Agent Skill authoring](references/agents/skill-authoring.md). Put that concise
+evidence summary in the pull-request description so a reviewer can evaluate the
+task model, research, responsibility boundaries, and observed behavior
+independently. When authoring stops before a pull request exists, preserve the
+same summary in the handoff. Keep lasting rules and subject understanding in
+their authoritative Skill, Knowledge, or reference rather than adding a design-
+history document. A mechanical-only change may use reduced evidence only when
+its summary explains why behavior is unchanged.
+
 ## Skill scopes
 
 Choose a Skill's location by its audience and lifecycle, not by its subject.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,9 +84,9 @@ evidence summary in the pull-request description so a reviewer can evaluate the
 task model, research, responsibility boundaries, and observed behavior
 independently. When authoring stops before a pull request exists, preserve the
 same summary in the handoff. Keep lasting rules and subject understanding in
-their authoritative Skill, Knowledge, or reference rather than adding a design-
-history document. A mechanical-only change may use reduced evidence only when
-its summary explains why behavior is unchanged.
+their authoritative Skill, Knowledge, or reference rather than adding a
+document that records design history. A mechanical-only change may use reduced
+evidence only when its summary explains why behavior is unchanged.
 
 ## Skill scopes
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.30-1",
+  "version": "2026.8.30-2",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/references/agents/skill-authoring.md
+++ b/references/agents/skill-authoring.md
@@ -2,67 +2,159 @@
 
 ## Scope
 
-This reference supports workflow steps for writing and reviewing reusable Agent Skills that are portable, reliably invoked, structurally focused, and behaviorally correct.
+Use this reference when writing or reviewing a reusable Agent Skill. It defines
+how to turn a real user task into a portable, reliably invoked workflow that
+contains enough professional understanding, decisions, and behavioral evidence
+to produce its promised result.
 
 ## When to update
 
-Update this document when a real authoring or review case exposes a missing rule for Skill portability, invocation, bundle structure, disclosure, or behavioral validation.
+Update this document when a real authoring or review case exposes a missing or
+incorrect rule for task modeling, professional research, responsibility
+placement, invocation, workflow behavior, bundle structure, or validation.
 
-## Keep references portable
+## Define the real task
 
-Refer to another Skill by its registered name rather than an installation path. Read shared packaged files directly unless the client explicitly guarantees Skill orchestration.
+Start from the result the user is trying to obtain, not from the requested file
+type, the first wording of the request, or the boundaries of an existing Skill.
+Before designing the workflow, establish:
 
-Resolve bundled resources relative to the current Skill. Discover project files and external authorities from the active working directory rather than embedding one source project's layout.
+- the observable user result and the range of realistic starting inputs, from
+  minimal or disorganized requests to already settled specifications;
+- the investigation, judgment, creative or technical decisions, and quality
+  control a competent practitioner performs to produce that result;
+- which facts the Agent can establish, which consequential choices require the
+  user, which low-risk gaps the Agent may fill, and which conflicts or missing
+  evidence must stop the work;
+- the adjacent tasks whose different inputs, result, or completion state make
+  them separate invocations; and
+- the success, failure, and stopping states by which the user can tell whether
+  the task was completed.
 
-## Make invocation and disclosure complete
+Treat those points as design questions, not as a form to copy into the Skill or
+a questionnaire to impose on the user. Use information already available from
+the conversation, artifacts, project, or prior work regardless of how it was
+obtained, and do not make the workflow repeat settled research or decisions.
 
-Put every distinct trigger branch in the frontmatter description. State the capability and task conditions there, and keep execution details in the body.
+Research the professional task before treating the current repository or the
+author's prior knowledge as complete. Read applicable existing Knowledge, then
+use current authoritative sources when the task depends on unfamiliar,
+specialized, evolving, or quality-sensitive subject matter. Prefer primary
+technical sources, professional institutions, established subject references,
+and first-party practitioner material as appropriate to the domain. Convert the
+research into decisions the workflow can execute; a source list or vocabulary
+list is not a substitute for professional task understanding.
 
-Define each trigger branch by the general task condition that makes the Skill
-applicable. Add examples only when they distinguish an otherwise ambiguous
-boundary, and introduce them after the complete condition so they cannot stand
-in for it.
+Treat a professional responsibility as required only when current evidence ties
+it to the promised result and its omission creates an observable failure. A
+reviewer's preferred technique, optional enhancement, or subjective taste does
+not establish a blocking requirement.
 
-Write task-facing instructions in imperative form. Keep the invocation
-contract, primary workflow, decisions that select supporting material, and
-completion criteria in the main file. Preserve enough context there for every
-execution path to reach the right material. Disclose supporting facts,
-criteria, or procedures when a workflow decision selects them or when delayed
-retrieval improves a long sequence or an overgrown information hierarchy. Keep
-one authoritative copy of each rule.
+A Skill that performs a genuinely mechanical transformation may require little
+domain research, but reach that conclusion from the task model rather than
+assuming it from a short user request or simple output format.
 
-## Design the Skill bundle by responsibility
+## Assign knowledge and execution responsibilities
 
-Read the complete affected Skill bundle and the routes or consumers needed to
-understand it before changing its structure. Treat the current files as
-evidence of the existing design, not as a boundary the final design must
-preserve. Organize the bundle by independently owned responsibility, retrieval
-timing, consumers, and maintenance lifecycle rather than by edit history or the
-operation that introduced the content.
+Use [Classifying Knowledge and Skill material](knowledge-and-skills.md) to place
+each part by its retrieval and execution responsibility. Independently
+retrievable subject understanding belongs in Knowledge, task execution belongs
+in the Skill, and supporting material selected only after invocation belongs in
+the Skill or a Skill reference. Complete missing Knowledge before finalizing a
+workflow that depends on it.
 
-For each responsibility, select the information-hierarchy tier established
-above. A separate Skill requires an independently invocable responsibility with
-its own user outcome and completion state; do not replace progressive
-disclosure with Skill-to-Skill orchestration.
+Draw Skill boundaries around independently invoked user tasks. A separate Skill
+needs its own triggering task, accepted input state, user-visible result, or
+completion state. Different professional domains can remain branches of one
+Skill when the user task and workflow are the same, while two tasks that share
+the same Knowledge remain separate Skills when their direction or completion
+differs. Do not use Skill-to-Skill orchestration as a substitute for a correct
+task boundary or progressive disclosure.
 
-After applying the active project's package-boundary rules, split a reference
-when the resulting units have distinct selecting decisions, consumer sets,
-responsibilities, or maintenance lifecycles. Merge references when those
-properties coincide and separate files preserve only historical edits. Do not
-use file length, step count, or reference count as an automatic split or merge
-rule.
+Keep reusable Skills portable. Resolve bundled resources relative to the Skill,
+read shared packaged files directly unless the client guarantees orchestration,
+and discover project paths, policies, domain rules, and external authorities
+from the active working directory. Do not embed one downstream project's layout
+or private infrastructure in a usage Skill. When a textual reference to another
+Skill is necessary, use its registered name rather than an installation path.
 
-Replace superseded workflow steps and remove obsolete routes rather than
-retaining chronological layers. The final bundle should expose one
-authoritative current workflow for each invocation and should contain no
-orphaned reference or duplicated rule.
+Organize the bundle by responsibility, selection timing, consumers, and
+maintenance lifecycle rather than by edit history. Keep one authoritative copy
+of each rule. Split a reference only when its selecting decision, consumers,
+responsibility, or lifecycle differs; merge references when those properties
+coincide. File length, step count, and reference count are not structural rules.
 
-## Verify behavior, not only structure
+## Write the executable workflow
 
-Validate frontmatter, references, formatting, metadata, and every changed route
-through the bundle. When static checks cannot establish invocation, selection,
-decision, failure, or completion behavior, forward-test representative branches
-in a fresh or isolated context without disclosing the intended answer or the
-author's conclusions. Compare the original and final bundle so every semantic
-change is intentional and every moved or retained responsibility remains
-reachable at the right time.
+Put the complete general task condition and every distinct trigger branch in
+the frontmatter description. Add examples only after the general condition and
+only when they distinguish a boundary. A user should not need to know the Skill
+name or repeat the description's terminology to invoke it.
+
+Write the main path as ordered, direct, imperative task instructions. Keep the
+invocation contract, primary states and decisions, reference selectors, failure
+and stopping behavior, output contract, and completion criteria in `SKILL.md`.
+Disclose supporting facts, criteria, or procedures when a workflow step selects
+them, including when delayed retrieval improves a long sequence or overgrown
+information hierarchy. Keep enough context in the main file to reach them at
+the right time.
+
+Make every consequential decision owned and observable. Tell the Agent when to
+investigate facts, inspect supplied evidence, ask the user, follow an existing
+project decision, make a low-risk choice, or stop. Do not describe important
+professional dimensions merely as optional examples when omitting them can
+prevent the promised result. At the same time, do not turn attention points
+into a fixed checklist when their relevance depends on the task.
+
+Define completion as the promised user result with its material constraints
+satisfied, not merely as producing a file, prompt, report, or other artifact.
+Include quality review or feasibility checks when a competent practitioner
+would use them before delivery. Keep output requirements close enough to the
+completion gate that later branches cannot silently bypass them.
+
+Read the finished bundle as one selection graph. Remove obsolete routes,
+superseded behavior, duplicated rules, patch-layered qualifications, and
+references that no current workflow step selects. The result should present one
+coherent current workflow without requiring the reader to reconstruct its edit
+history.
+
+## Prove the behavior
+
+Treat a new Skill or a material behavior change as incomplete until its actual
+behavior is demonstrated. A material change includes invocation or exclusion
+conditions, accepted inputs, user or Agent decision authority, professional
+responsibilities, workflow states or branches, Knowledge or reference
+selection, tools or side effects, output contracts, failure behavior, completion
+criteria, or any wording likely to change execution. Purely mechanical changes
+may use proportionally smaller evidence only after confirming that semantics did
+not change.
+
+Derive scenarios from the task model and its risks rather than satisfying a
+fixed case count. Cover each applicable kind of evidence or explain concretely
+why it does not apply:
+
+- **Invocation evidence:** in a fresh or isolated context with the real
+  candidate set, use natural positive and adjacent negative requests without
+  revealing the expected Skill name or the author's conclusion.
+- **Workflow evidence:** exercise underspecified and already settled inputs, the
+  principal complex branch, material conflicts or missing evidence, and inputs
+  likely to tempt the Agent to skip investigation, decisions, or stopping
+  behavior.
+- **Output evidence:** verify the user-visible result, professional minimum,
+  declared inputs, material constraints, format, and completion gate rather than
+  checking only that an artifact was emitted.
+
+Record the scenario, expected behavior, observed behavior, and conclusion.
+Static validation still checks frontmatter, links, formatting, metadata,
+packaging, and complete routes, but it cannot replace semantic evidence for
+behavior it does not execute. Compare the trusted pre-change and final bundles
+so every changed responsibility is intentional and remains reachable.
+
+For a pull request that adds a Skill or materially changes one, summarize the
+user result and realistic starting inputs, professional task and research,
+responsibility boundaries and placement, and behavioral evidence. Keep this
+review evidence in the pull request or handoff rather than creating a permanent
+design-history document. Put every durable rule or subject insight in its
+authoritative Skill, Knowledge, or reference. Missing applicable design or
+behavioral evidence makes the change incomplete even when the prose appears
+plausible.


### PR DESCRIPTION
## Summary

- rewrite the canonical Skill-authoring reference around four ordered gates: define the real task, assign knowledge and execution responsibilities, write the executable workflow, and prove the behavior
- make artifact-specific analysis precede final artifact and operation selection in the repository maintenance workflow
- require reviewable design evidence for new or materially changed Skills and apply the same canonical standard in AI review and scheduled maintained-content verification

## Design evidence

### User result and realistic inputs

The intended result is that a structurally valid Skill cannot be accepted without showing that it can complete the real user task it promises. The authoring path must handle a vague new-Skill request, an already detailed proposal, a material change to an existing workflow, and a genuinely mechanical edit without treating all four as the same amount of work.

### Professional task and research

The design was derived from the repository's prior Skill-authoring and maintenance history, the current system `skill-creator` guidance, and the installed `writing-for-agents` guidance on context pointers, completion demand, progressive disclosure, pruning, and independent forward-testing. The durable conclusion is outcome-based: model the competent work behind the promised result, research specialized or quality-sensitive responsibilities, and require observable evidence without converting the process into a fixed form or scenario count.

### Responsibility boundaries

`references/agents/skill-authoring.md` is the sole owner of the task model, research, Skill-boundary, executable-workflow, and behavioral-evidence standard. The repository maintenance workflow owns sequencing and application; `AGENTS.md` owns PR evidence delivery; AI review owns current-PR enforcement; scheduled verification owns current-state reassessment without requiring historical PR evidence. No existing user Skill is reviewed or modified by this change.

### Behavioral evidence

- A fresh-author exercise for a hypothetical incident-retrospective Skill now follows one ordered route: artifact-specific task and research analysis, final artifact/operation selection, implementation, behavioral evidence, and one parent-owned semantic comparison.
- An anonymous live-event-planning counterfactual combines new planning, schedule editing, and failed-event diagnosis, treats professional concerns as optional examples, lets vague input go straight to output, and supplies only static checks. The authoring path rejects that structure before operation selection, and AI review independently reaches `needs-change` through both content defects and the missing-evidence gate.
- An independent aggregate semantic review verified that the rewritten documents preserve portability, the contribution-Skill exception, progressive disclosure, imperative workflow writing, route cleanup, and separate consumer authority without duplicated rules or historical layering.
- These exercises exposed and drove fixes for parent/child ordering, the contribution checkout exception, Knowledge-before-research sequencing, validation ownership, and overly narrow decision-only reference selection.

## Validation

- `python3 /Users/soulike/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/maintain-knowledge-base`
- `pnpm --filter @knowledge-base/ai-review test`
- `pnpm prompt-links:check`
- `pnpm check`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`
- `git diff --check origin/main...HEAD`
