### PR TITLE
Allow bounded review-remediation PR metadata updates

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.30-3",
+  "version": "2026.8.30-4",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/skills/watch-pull-request/references/capture-pr-state.md
+++ b/skills/watch-pull-request/references/capture-pr-state.md
@@ -2,8 +2,8 @@
 
 Retrieve one complete current snapshot from every applicable PR surface:
 
-- PR number, state, draft or terminal state, title, description, and
-  writeability;
+- PR number, state, draft or terminal state, title, description, any
+  provider-exposed metadata revision or update timestamp, and writeability;
 - base repository, ref, and SHA, together with source repository, ref, and SHA;
 - complete base-to-current-head commit history and aggregate diff, including
   changes published by earlier observation cycles;

--- a/skills/watch-pull-request/references/classify-pr-state.md
+++ b/skills/watch-pull-request/references/classify-pr-state.md
@@ -130,11 +130,13 @@ The exception accepts the small race in which any checked PR identity, state,
 head, title, or description changes after the refresh but before the write. It
 does not authorize adopting a changed identity or make automated review output
 authoritative: the finding and remediation must still be independently
-established, scoped, and verified. When any condition fails, keep the update
-human-only and preserve the current metadata. After a known successful
-response, any unexpected identity, state, head, title, or description is an
-inconsistent result that freezes further mutation and requires human
-intervention rather than a retry.
+established, scoped, and verified. When an eligibility or allowed-content
+condition in items 1, 2, or 4 fails, keep the update human-only and preserve the
+current metadata. A pre-write mismatch follows item 3's return to observation
+or contract establishment, while a failed or unknown invocation follows item
+5's reconciliation path. After a known successful response, any unexpected
+identity, state, head, title, or description is an inconsistent result that
+freezes further mutation and requires human intervention rather than a retry.
 
 ## Stop drift and remediation loops
 

--- a/skills/watch-pull-request/references/classify-pr-state.md
+++ b/skills/watch-pull-request/references/classify-pr-state.md
@@ -88,11 +88,53 @@ or explanation is human-only.
 
 An autonomous title or description update may correct stale wording, document
 implemented behavior or verification, or update an accurate checklist. It
-must preserve relevant human-authored context and linked issues, and the
-provider must reject the write when the observed metadata changed. Keep the
-update human-only when the provider has no conditional write, the framing or
-scope is disputed, or the change would introduce a release, compatibility, or
-policy commitment.
+must preserve relevant human-authored context and linked issues.
+
+For an ordinary metadata update, require the provider to reject the write when
+the observed title or description changed. Keep the update human-only when the
+provider has no conditional write, the framing or scope is disputed, or the
+change would introduce a release, compatibility, policy, or risk commitment.
+
+A title or description update needed to finish remediation of an automated
+review finding may instead use a bounded refresh-write-verify sequence without
+a provider conditional write. Treat that narrow metadata as reproducible
+remediation output rather than protected state. Apply the exception only when
+every condition holds:
+
+1. The finding passed the complete review-finding disposition gate, its
+   remediation is inside the accepted PR intent, and the source change,
+   validation, evidence collection, or other substantive work is complete and
+   verified.
+2. The completed remediation makes the current title or description factually
+   stale or incomplete, and the exact replacement follows from the published
+   head and recorded evidence without a new framing, scope, product, design,
+   architecture, compatibility, security, release, policy, or risk choice.
+3. Immediately before writing, retrieve the complete current PR identity,
+   source head, title, description, and any provider-exposed metadata revision
+   or update timestamp. Require the canonical repository, PR number and state,
+   base repository, ref, and SHA, and source repository, ref, and SHA to match
+   the classified remediation baseline exactly. A mismatch returns to complete
+   observation or contract establishment without invoking the update.
+   Construct the update from the freshly retrieved title and description rather
+   than from an earlier snapshot, preserving every unrelated human-authored
+   statement, linked issue, and still-current fact.
+4. Change only the title, description, or both. Do not use this exception to
+   mutate any other PR metadata or to rewrite content unrelated to the handled
+   finding.
+5. Invoke the update once, then retrieve the complete PR identity, source head,
+   title, and description again. Completion requires the classified remediation
+   identity and head plus the exact intended metadata. Reconcile a failed or
+   unknown result before considering another attempt.
+
+The exception accepts the small race in which any checked PR identity, state,
+head, title, or description changes after the refresh but before the write. It
+does not authorize adopting a changed identity or make automated review output
+authoritative: the finding and remediation must still be independently
+established, scoped, and verified. When any condition fails, keep the update
+human-only and preserve the current metadata. After a known successful
+response, any unexpected identity, state, head, title, or description is an
+inconsistent result that freezes further mutation and requires human
+intervention rather than a retry.
 
 ## Stop drift and remediation loops
 

--- a/skills/watch-pull-request/references/establish-watch-contract.md
+++ b/skills/watch-pull-request/references/establish-watch-contract.md
@@ -48,8 +48,10 @@ select them as autonomous:
 - reply to top-level comments and review threads, and resolve completely
   disposed review threads;
 - rerun one clearly transient, validation-only CI replay unit; and
-- factually maintain the PR title or description through a provider-supported
-  conditional update tied to the observed metadata state.
+- factually maintain the PR title or description under the metadata
+  classification and reconciliation rules, including their bounded exception
+  for recording completed automated-review remediation when the provider lacks
+  a conditional write.
 
 Keep every other mutation human-only, including changes to labels, assignees,
 milestones, requested reviewers, conversion from ready for review back to

--- a/skills/watch-pull-request/references/reconcile-unknown-effect.md
+++ b/skills/watch-pull-request/references/reconcile-unknown-effect.md
@@ -26,6 +26,16 @@ current resolved state before repeating the mutation. For metadata or CI,
 identify the intended version or replay attempt rather than inferring success
 from a generic PR summary.
 
+For a title or description update performed through the automated-review
+remediation exception, query the exact PR identity, source head, title,
+description, and any provider-exposed metadata revision or update timestamp.
+The exact intended title and description at the expected identity and head
+establish completion. The exact pre-write metadata with an unchanged provider
+revision or update timestamp establishes non-completion, but another attempt
+still requires a fresh complete observation and classification. Any other
+result is an unexplained concurrent or partial state; preserve it and require
+human intervention rather than overwriting it or replaying the stale update.
+
 For a ready-for-review transition, apply
 [Pull request review readiness](../../../references/github/pull-request-review-readiness.md)
 as the authoritative reconciliation and mutation-freeze policy.


### PR DESCRIPTION
## Summary

- allow a pull-request watcher to update a title, description, or both without provider conditional-write support when the update is the remaining factual publication of independently verified automated-review remediation
- bind the exception to the classified PR/base/source identity and remediation head while incorporating the freshest title and description
- verify the exact post-write state and define bounded reconciliation for unknown outcomes
- keep ordinary metadata maintenance and all new framing, scope, release, compatibility, security, policy, and risk choices protected
- update the primary plugin version to `2026.8.30-4`

## Design evidence

### User result and starting inputs

A watcher may finish an in-scope automated-review remediation whose source changes, validation, or behavioral evidence makes the current PR title or description factually stale. Some providers do not offer a conditional metadata write. The workflow must publish that derived factual metadata without turning automated review output into authority or weakening unrelated metadata and identity protections.

### Responsibility boundaries

- `establish-watch-contract.md` exposes the bounded title/description authority without duplicating its policy.
- `capture-pr-state.md` adds the provider metadata revision or update timestamp needed by the write and reconciliation paths.
- `classify-pr-state.md` owns exception eligibility, the immediate refresh, exact baseline identity check, one write, post-write verification, and the accepted race.
- `reconcile-unknown-effect.md` owns completion, proven non-completion, and unexplained-result handling after an unknown metadata mutation.
- the main Skill selection graph is unchanged because it already retrieves all four references at the applicable stages.

### Trust and concurrency model

The automated finding still passes the complete review-finding disposition gate and cannot expand accepted intent. Before writing, the canonical repository, PR number/state, complete base identity, and complete source identity/head must equal the classified remediation baseline. Only the freshly observed title and description may be incorporated. A mismatch returns to observation without writing. The exception explicitly accepts the narrow check-then-act race after this refresh; exact readback establishes completion, while inconsistent known-success or unexplained unknown outcomes freeze mutation and require human intervention.

### Behavioral evidence

Fresh read-only scenarios exercised the changed workflow:

1. A verified, published automated-review remediation that made the title and description factually incomplete was classified as autonomous even without provider conditional writes. The evaluator required a fresh full identity/metadata read, one update, exact readback, and bounded timeout reconciliation.
2. A routine title cleanup without automated-review remediation remained human-only when no conditional write existed.
3. An automated-review proposal that required new compatibility policy and PR reframing could not use the exception and required the normal scope/authority disposition.
4. A known-success update followed by an unexpected title or source head froze further mutation and required human intervention.
5. A pre-write refresh that observed a new source head or changed base identity could not adopt it; it returned to complete observation or contract establishment before any later attempt.

A fresh semantic comparison found and corrected two draft defects: the refresh now rejects every identity/head mismatch instead of adopting it, and the exception explicitly preserves the human gate for release commitments. The final comparison found no unexplained semantic loss or duplicate authority.

## Validation

- `python3 /Users/soulike/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/watch-pull-request`
- `pnpm check`
- `git diff --check`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`
