### PR TITLE
Clarify how examples explain abstract documentation rules

### DIFF
--- a/knowledge/documentation/maintained-document-quality.md
+++ b/knowledge/documentation/maintained-document-quality.md
@@ -84,11 +84,19 @@ specialized vocabulary before relying on it. Use lists, tables, diagrams, and
 other structures only when they make the information easier to understand or
 apply; no format is a quality requirement by itself.
 
-Use an example when it resolves a real comprehension or application problem.
-Make it accurate, representative, small enough to understand, and explicit
-about the choice or result it demonstrates. State the broader rule so the
-example does not silently narrow the supported cases or become an accidental
-requirement.
+Use an example only when it resolves a real comprehension or application
+problem. An abstract rule benefits from one when it permits several plausible
+applications or when readers must distinguish a boundary that prose alone
+leaves ambiguous. Do not add an example to a self-evident declaration, a simple
+fact, or a rule with only one practical interpretation.
+
+State the general rule before the example. Make the example accurate,
+representative, small enough to understand, and explicit about the choice or
+result it demonstrates; retain only the context needed to understand that
+choice. When a boundary matters, place a matching example beside a non-matching
+example when the contrast materially clarifies it. Keep every example
+illustrative: it must not silently narrow the rule, impose a technology-specific
+requirement, or turn one incident into universal guidance.
 
 ## Maintain and validate the result
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.8.30-6",
+  "version": "2026.8.31-1",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }


### PR DESCRIPTION
Closes #55

## Summary

- explain when an abstract documentation rule benefits from an example and when an example would be unnecessary decoration
- require the general rule to precede its illustration and recommend adjacent matching and non-matching examples when contrast materially clarifies a boundary
- keep examples representative and illustrative without turning one technology or incident into a universal requirement

## Responsibility and evidence

The existing maintained-document-quality Knowledge already owns example selection and reader comprehension. This change rewrites that complete responsibility block in place; it does not add a new Knowledge route or duplicate the rule in the documentation Skills. The Dragon module-responsibility case from #55 supplies the authoring evidence, while project-specific history remains outside the reader-facing Knowledge.

The resulting rule was checked against four cases: an abstract rule with several plausible applications, an ambiguous boundary, a self-evident fact, and a project-specific incident. They respectively select an illustrative example, a matching/non-matching contrast, no example, and only the context needed to understand the general choice.

## Validation

- `pnpm check`
- `git diff --check`
- independent semantic comparison against #55, the prior Knowledge, its index route, and its Skill consumers