### PR TITLE
Refresh npm clean-install verification baseline

### DIFF
--- a/knowledge/npm/clean-install-cache.md
+++ b/knowledge/npm/clean-install-cache.md
@@ -76,6 +76,11 @@ the same lockfile-selected dependency graph and the same accepted
 integrity-verified package content. Changing that result is a correctness
 failure, not an acceptable performance tradeoff.
 
+First establish that this fixed baseline satisfies the project's intended
+installation behavior. Matching control and candidate results do not validate
+a baseline made incomplete by a separate npm-version, configuration, or
+installation-policy change.
+
 Preserve every tree-shaping flag used to create the lockfile and the project's
 existing policies for lifecycle scripts, approved native builds, registry and
 authentication settings, audit, and failure recovery. `--prefer-offline`

--- a/knowledge/npm/clean-install-cache.md
+++ b/knowledge/npm/clean-install-cache.md
@@ -18,7 +18,7 @@ applicability condition, or efficiency proof.
 ## Verify the current behavior
 
 The mappings in this document were verified against
-[npm CLI 11.19.1](https://github.com/npm/cli/tree/v11.19.1) and
+[npm CLI 12.0.2](https://github.com/npm/cli/tree/v12.0.2) and
 [`actions/setup-node` at commit `94196ee`](https://github.com/actions/setup-node/tree/94196ee1d15439c1b6651cd87ef14e88ec435966).
 Before changing an installation that uses another version, verify its current
 clean-install, cache, network-fallback, integrity, audit, and configuration
@@ -62,7 +62,7 @@ or unusable entry is intended.
 
 Cache preference does not disable integrity verification. With
 `--prefer-offline`, missing package data can still be fetched, and enabled
-install-time audit behavior can make its own requests. In npm CLI 11.19.1,
+install-time audit behavior can make its own requests. In npm CLI 12.0.2,
 strict `--offline` instead suppresses the install-time audit report even when
 audit is enabled. A project that requires that security gate must retain an
 online install mode or run a separate online audit step.
@@ -143,10 +143,10 @@ condition is false or cannot be established.
 
 ## References
 
-- [npm cache documentation](https://github.com/npm/cli/blob/v11.19.1/docs/lib/content/commands/npm-cache.md)
-- [npm ci documentation](https://github.com/npm/cli/blob/v11.19.1/docs/lib/content/commands/npm-ci.md)
-- [npm cache-preference definitions](https://github.com/npm/cli/blob/v11.19.1/workspaces/config/lib/definitions/definitions.js)
-- [npm registry-fetch cache-mode mapping](https://github.com/npm/cli/blob/v11.19.1/node_modules/npm-registry-fetch/lib/index.js)
-- [npm offline audit behavior](https://github.com/npm/cli/blob/v11.19.1/workspaces/arborist/lib/audit-report.js)
+- [npm cache documentation](https://github.com/npm/cli/blob/v12.0.2/docs/lib/content/commands/npm-cache.md)
+- [npm ci documentation](https://github.com/npm/cli/blob/v12.0.2/docs/lib/content/commands/npm-ci.md)
+- [npm cache-preference definitions](https://github.com/npm/cli/blob/v12.0.2/workspaces/config/lib/definitions/definitions.js)
+- [npm registry-fetch cache-mode mapping](https://github.com/npm/cli/blob/v12.0.2/node_modules/npm-registry-fetch/lib/index.js)
+- [npm offline audit behavior](https://github.com/npm/cli/blob/v12.0.2/workspaces/arborist/lib/audit-report.js)
 - [`actions/setup-node` cache documentation](https://github.com/actions/setup-node/blob/94196ee1d15439c1b6651cd87ef14e88ec435966/README.md)
 - [`actions/setup-node` npm cache implementation](https://github.com/actions/setup-node/blob/94196ee1d15439c1b6651cd87ef14e88ec435966/src/cache-utils.ts)

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.9.4-1",
+  "version": "2026.9.4-2",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }


### PR DESCRIPTION
## Summary

- revalidate the npm clean-install cache guidance against npm CLI 12.0.2
- update the pinned npm sources and the version-specific offline-audit statement
- require the fixed comparison baseline itself to satisfy the intended installation behavior
- preserve the existing `--prefer-offline` responsibility and installation-policy comparison boundary
- bump the primary plugin version to `2026.9.4-2`

## Evidence and boundaries

- independently checked npm 12.0.2 cache integrity, clean-install, cache-mode, network-fallback, and offline-audit behavior against upstream documentation and source
- reproduced the npm 12 dependency-script policy change, but kept `allowScripts`, approval, and rebuild procedures out of this cache-preference Knowledge because the existing version-independent installation-script comparison invariant already covers the relevant boundary
- clarified that matching control and candidate results cannot validate a baseline made incomplete by a separate npm-version, configuration, or installation-policy change
- confirmed that the pinned `actions/setup-node` commit remains current and still caches npm package-manager data rather than `node_modules`
- left the Knowledge scope, update trigger, index route, and performance-comparison model unchanged

## Validation

- `pnpm check`
- `pnpm knowledge:check`
- `pnpm links:check`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`
- `git diff --check origin/main...HEAD`
- independent semantic comparison: no findings

Closes #81