### PR TITLE
Use adaptive polling when watching pull requests

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.9.8-1",
+  "version": "2026.9.8-2",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/skills/watch-pull-request/SKILL.md
+++ b/skills/watch-pull-request/SKILL.md
@@ -9,6 +9,9 @@ description: Watch or resume watching a trusted or verified pull request across 
 
 Read [Establish the watch contract](references/establish-watch-contract.md) and
 [Security boundaries and trust transitions](../../references/security/security-boundaries.md).
+When resuming a checkpointed watch, also read
+[Wait and hand off](references/wait-and-handoff.md) and complete its resume
+safeguards before observation.
 When the pull request is draft or the accepted intent may include entering
 review, also read
 [Pull request review readiness](../../references/github/pull-request-review-readiness.md)
@@ -21,6 +24,10 @@ trusted control revision, accepted intent, access, safe workspace, or mutation
 boundary.
 
 ## Run observation cycles
+
+Start a new watch, or resume one after completing the safeguards above, by
+entering this observation cycle for immediate complete state capture and
+classification.
 
 Repeat this cycle until its wait, handoff, or terminal condition applies:
 

--- a/skills/watch-pull-request/references/wait-and-handoff.md
+++ b/skills/watch-pull-request/references/wait-and-handoff.md
@@ -22,6 +22,11 @@ any remaining scheduled poll, retrieve one complete current PR state, and begin
 a new observation cycle. The event is only a wake-up signal; the newly
 retrieved complete state remains authoritative.
 
+Treat each scheduled interval as one passive wait. Continue that same wait
+through runtime yields, tool returns, or execution continuations that occur
+before the deadline without a relevant event. They do not trigger a provider
+read, interval recalculation, or progress update.
+
 When an observation enters or returns to waiting, schedule a five-minute poll
 if no preceding waiting state is retained from the current execution. When a
 preceding state exists, restart with a five-minute interval if a semantic change

--- a/skills/watch-pull-request/references/wait-and-handoff.md
+++ b/skills/watch-pull-request/references/wait-and-handoff.md
@@ -8,9 +8,49 @@ needs a human decision or human intervention.
 
 ## Wait and resume
 
-Use the runtime's native waiting or monitoring mechanism when available. On a
-relevant event or poll result, retrieve a new complete PR state and begin a new
-observation cycle. Do not post periodic or no-op status comments.
+An observation cycle enters the waiting path only after retrieving and
+classifying one complete current PR state and finding that every active item is
+waiting for an expected external result. Within one persistent execution,
+retain that waiting state and its scheduled polling interval until the next
+observation classifies the current state.
+
+Prefer a runtime mechanism that can wake on a relevant event without
+periodically retrieving provider state. Treat a monitor that refreshes provider
+state periodically as polling and apply the polling cadence below. Race a
+relevant event against the scheduled poll. When either wakes the watch, cancel
+any remaining scheduled poll, retrieve one complete current PR state, and begin
+a new observation cycle. The event is only a wake-up signal; the newly
+retrieved complete state remains authoritative.
+
+When an observation enters or returns to waiting, schedule a five-minute poll
+if no preceding waiting state is retained from the current execution. When a
+preceding state exists, restart with a five-minute interval if a semantic change
+affects an active item's identity, status, content, or disposition. Passage of
+time and provider metadata that does not affect classification do not reset the
+interval.
+
+When the observation returns to waiting with unchanged state, determine the
+next interval as follows:
+
+1. For each active item, use recent completed samples already available through
+   the normal watch when they represent the same awaited result under
+   materially comparable conditions. Estimate the typical total time to that
+   result and subtract the current elapsed time measured from the corresponding
+   boundary. Choose the completion unit from the awaited result rather than a
+   fixed provider object: when one complete review is the result, its internal
+   jobs or checks are stages of that sample rather than separate completion
+   samples.
+2. When an item's estimate has passed, give it a five-minute candidate. When
+   estimated time remains, use
+   `clamp(estimated remaining time / 2, 5 minutes, 10 minutes)`.
+3. When no credible estimate is available for an item, give it a candidate five
+   minutes longer than the previous polling interval, capped at ten minutes.
+4. Schedule the shortest candidate across all active items.
+
+This produces a deterministic fallback of five minutes and then ten minutes
+while allowing applicable duration patterns observed during the watch to
+shorten a later interval. Do not create a separate mandatory history-retrieval
+loop or post periodic or no-op status comments.
 
 When persistent waiting is unavailable or execution stops, checkpoint the
 watch contract, last complete PR identity, safe workspace and local work,
@@ -19,10 +59,10 @@ remaining dispositions, the readiness transition-history baseline and consumed
 one-shot authority, and every mutation with an unknown result. State that
 monitoring stopped; never claim to remain watching after execution ends.
 
-On resume, verify workspace ownership, reconcile unknown effects, and retrieve
-a complete current PR state before starting work. Preserve local state whose
-ownership or publication result cannot be established and require human
-intervention when it cannot be made safe.
+On resume, verify workspace ownership, reconcile unknown effects, and return to
+the observation cycle immediately. Preserve local state whose ownership or
+publication result cannot be established and require human intervention when
+it cannot be made safe.
 
 ## Verify the handoff state
 


### PR DESCRIPTION
## Problem and resulting behavior

`watch-pull-request` previously preferred native waiting or monitoring without defining a polling cadence or distinguishing event-driven wake-ups from native commands that poll every few seconds. A watch could therefore repeatedly retrieve the complete PR state while CI or review was still progressing.

The watch now observes a new or resumed PR immediately after the existing resume safeguards, enters waiting only after classification finds no executable or human-only work, and keeps remote polling between five and ten minutes. Relevant events still wake observation immediately. A monitor that periodically refreshes provider state follows the same polling cadence, while runtime yields without an event continue the same passive wait without another provider read or progress update.

Closes #104.

## Design and responsibility

The existing `Wait and resume` responsibility remains authoritative for waiting cadence. The main Skill only routes checkpoint resumes through their existing workspace and unknown-effect safeguards before the immediate observation cycle.

Within one persistent execution, the waiting path retains the preceding waiting state and polling interval. A first waiting state or semantic change schedules five minutes. Unchanged state uses recent completed samples of the same awaited result when they are readily available through the normal watch; otherwise the previous interval increases by five minutes and caps at ten. Each active item produces a candidate, and the shortest candidate is scheduled. The completion unit follows the awaited result, so one complete review is one sample and its internal jobs remain stages.

Each selected interval is one passive wait. A runtime yield, tool return, or continuation before its deadline does not end that wait unless it carries a relevant event; it performs no provider read, interval recalculation, or progress update.

GitHub CLI documents short default refresh intervals for native watch commands, confirming that a native watcher is not necessarily event-driven: [`gh pr checks`](https://cli.github.com/manual/gh_pr_checks) defaults to ten seconds and [`gh run watch`](https://cli.github.com/manual/gh_run_watch) defaults to three seconds. The Skill therefore classifies behavior by whether provider state is periodically retrieved rather than by a command or runtime feature name.

No new Knowledge, Skill, reference, history-fetch workflow, persistent cadence state, or automated test artifact is introduced. The root plugin version advances to `2026.9.8-2`.

## Behavioral evidence

The Skill bundle was exercised as the public interface in isolated contexts with explicit simulated timelines.

| Scenario | Pre-change observation | Final observation |
| --- | --- | --- |
| New watch with executable work | Immediate observation already existed | Immediate capture and classification remain before any wait |
| Checkpoint resume with an unknown effect | Existing safeguards preceded resumed work | Main routing selects those safeguards, then performs one immediate complete observation |
| Unchanged state without samples | No interval was defined | Complete observations follow `5 → 10 → 10` minutes |
| Useful review-duration samples | No sample or completion-unit rule existed | An 18-minute complete-review pattern with 6 minutes elapsed produces a 6-minute candidate; internal jobs are not separate samples |
| Several active items | No aggregation rule existed | Candidates of 6 and 10 minutes schedule the next observation after 6 minutes |
| Semantic state change | No reset rule existed | Identity, status, content, or disposition changes reset to five minutes; time passage and irrelevant metadata do not |
| Event before a scheduled poll | Event observation was only partially defined | The event cancels the poll and retrieves complete state immediately; changed state resets to five minutes and unchanged state uses the retained interval |
| Native monitor that internally polls | A short-interval native watcher was allowed | Periodic provider refresh is polling and remains subject to the five-to-ten-minute cadence |
| Runtime yields before the deadline without an event | The previous wording did not define their effect | The same passive wait continues with no provider read, interval recalculation, or progress update |

The trusted pre-change bundle, current Issue #104, and final bundle were also compared independently. The comparison found no unexplained loss, duplicate authority, routing gap, downstream-project assumption, or change to checkpoint and handoff responsibilities. Final Standards and Spec reviews reported no findings at head `72845de`.

## Validation

- `pnpm check`
- `python3 /Users/soulike/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/watch-pull-request`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`
- `git diff --check origin/main...HEAD`
