### PR TITLE
Budget nested test deadline hierarchies

### DIFF
--- a/knowledge/software-testing/trustworthy-test-execution.md
+++ b/knowledge/software-testing/trustworthy-test-execution.md
@@ -201,9 +201,52 @@ A protocol that cannot reproduce the failure can narrow hypotheses but does not
 establish a cause. Compare pre- and post-change executions using the same
 relevant conditions and record when a pre-change sample is unavailable.
 
+## Budget diagnostic deadline hierarchies
+
 A timeout is a diagnostic bound, not evidence that an awaited condition is
-ready. Increase one only when valuable behavior is protected, the real
-integration seam is already minimal, no production or harness defect explains
-the delay, avoidable setup work is absent, and measurements show a bounded
-runtime distribution beyond the existing limit. Keep the override local and
-leave enough margin for failure propagation and cleanup.
+ready or that elapsed time is itself the protected behavior. Increase one only
+when valuable behavior is protected, the real integration seam is
+already minimal, no production or harness defect explains the delay, avoidable
+setup work is absent, and measurements show a bounded runtime distribution
+beyond the existing limit. Keep an override local.
+
+Map every effective timeout, including defaults and overrides, to the exact
+lifecycle phases that its runner or operation governs. A test-body deadline can
+exclude hooks or teardown, while a worker, suite, fixture, or run deadline can
+impose another outer bound. Treat a deadline as outer only for the phases that
+its documented lifecycle covers.
+
+For each governing outer deadline, calculate the longest reachable wall-clock
+path through its phases. Sum the maximum relevant bounds of sequential work.
+For concurrent work, use the longest reachable critical path only when the
+operations actually overlap under their dependencies, runner scheduling, and
+resource constraints. Account for command discovery and startup, setup,
+reachable retries and retry delays, failure propagation, cancellation, process
+or resource settlement, and cleanup when they consume that same budget. Use the
+longest reachable alternative rather than summing mutually exclusive paths.
+
+An inner deadline being numerically lower than an outer deadline is
+insufficient when several bounded operations can run sequentially. When an
+inner failure is intended to provide the useful diagnostic, its governing outer
+deadline must leave time for that failure to occur and propagate and for owned
+work to settle or cancel before applicable cleanup. This numeric hierarchy is
+necessary but not sufficient: timer delivery can be late, and an expired
+timeout, abort request, or sent termination signal does not establish resource
+settlement.
+
+Prefer asynchronous, cancellable APIs for test-owned operations that may block
+on a process, service, transport, filesystem, or other external resource, and
+await completion or confirmed cancellation before cleanup. Short deterministic
+synchronous work does not require conversion merely because it is synchronous.
+Do not assume that a runner deadline can preempt longer synchronous blocking
+work: when enforcement depends on the same execution thread, the runner cannot
+act until that work returns or yields, and the resulting pass, failure, or
+delayed timeout is runner-specific. When synchronous behavior belongs to the
+protected contract, retain a representative case with an operation-level
+enforceable bound, or isolate it behind a worker or process that an independent
+watchdog can terminate before the test confirms settlement.
+
+A deliberately enforced performance deadline is a separate behavior contract.
+Establish its requirement through [Test effectiveness](test-effectiveness.md)
+and apply [Test execution cost](test-execution-cost.md) to its measurements and
+comparisons instead of treating it as diagnostic margin.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.9.8-2",
+  "version": "2026.9.9-1",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }


### PR DESCRIPTION
Tests can give every child operation an individually smaller timeout and still let a governing runner deadline expire before the useful inner diagnostic, owned-work settlement, or cleanup. This change extends the existing Trustworthy test execution Knowledge with one framework-independent model for mapping effective deadlines to lifecycle phases and budgeting the longest reachable wall-clock path.

## Changes

- inventory effective runner and operation timeouts, including defaults and overrides, against the lifecycle phases each one governs
- sum sequential bounds and use the longest actually overlapping critical path under dependency, scheduling, and resource constraints
- include reachable retries, startup, failure propagation, cancellation, settlement, and cleanup in the governing budget
- state that numeric timeout ordering is necessary but does not prove timely timer delivery, cancellation, or settlement
- prefer asynchronous, cancellable APIs for test-owned external operations while preserving short deterministic synchronous work
- retain representative synchronous contract cases behind an enforceable operation bound or independently supervised worker or process
- keep performance deadlines with the existing test-effectiveness and test-execution-cost owners
- publish primary plugin version `2026.9.9-1`

The existing Knowledge index and test Skill triggers already route timeout, process, cleanup, concurrency, and intermittent-execution tasks to this document, so they remain unchanged. Source-project timing values are retained only as issue evidence and do not become reusable thresholds.

## Evidence

Neutral checks with Node.js v26.8.1 observed:

- two sequential 40 ms waits exceeded a 60 ms test timeout
- two genuinely overlapping 40 ms waits completed in about 41 ms
- a 50 ms outer timeout replaced an inner diagnostic arriving after 80 ms
- timeout cleanup began before the cancelled asynchronous body settled
- a synchronous callback blocking for about 120 ms passed despite a 50 ms runner timeout

Node documents that synchronous child-process APIs block the event loop and that timer scheduling has no exact delivery guarantee. Playwright documents separate timeout allowances for test setup/body, teardown, hooks, fixtures, assertions, and the overall run. These sources support the mechanism while preventing one runner's outcome from becoming a universal rule.

An independent semantic comparison initially found that “configured timeout” omitted implicit defaults. The final wording inventories every effective default and override, and the repeated comparison found no remaining loss, overclaim, duplicate authority, routing gap, or source-project dependency.

## Validation

- `pnpm knowledge:check`
- `pnpm check`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`
- `git diff --check origin/main...HEAD`
- neutral sequential, parallel, blocking, masking, and cleanup-lifecycle scenarios
- independent semantic comparison against `origin/main`, #103, all affected artifacts, routes, and consumers

Closes #103.
