### PR TITLE
Require lower-capability validation for Skill behavior

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.9.8-2",
+  "version": "2026.9.9-1",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.9.9-1",
+  "version": "2026.9.9-2",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/references/agents/skill-authoring.md
+++ b/references/agents/skill-authoring.md
@@ -144,15 +144,20 @@ why it does not apply:
   declared inputs, material constraints, format, and completion gate rather than
   checking only that an artifact was emitted.
 
-Run invocation and workflow evidence with a different supported model that is
-materially less capable for the evaluated task than the model used to author
-the change. Record the authoring model and any exposed capability-relevant
-configuration before selecting the evaluator. Choose a model that still has the
-required modalities, tools, and context, and justify its lower-capability
-baseline from relevant evidence rather than its name or price alone. A lower
-reasoning effort on the authoring model does not provide this cross-model
-evidence. Treat inability to establish the model comparison, or otherwise
-unavailable applicable cross-model evidence, as an incomplete result.
+Before running invocation and workflow evidence, identify one comparison model
+for the evaluated task. When one or more models materially authored the behavior
+under test, use the most capable of them for that task. For human-only
+authorship, select the most capable supported model available to the authoring
+environment for that task. Record the comparison model, the basis for selecting
+it, and any exposed capability-relevant configuration.
+
+Run the evidence with a different supported model that is materially less
+capable for the evaluated task than the comparison model. Choose a model that
+still has the required modalities, tools, and context, and justify its
+lower-capability baseline from relevant evidence rather than its name or price
+alone. A lower reasoning effort on the comparison model does not provide this
+cross-model evidence. Treat inability to establish the model comparison, or
+otherwise unavailable applicable cross-model evidence, as an incomplete result.
 
 Use the lower-capability run to test whether invocation and procedure are
 self-sufficient, not as the sole judgment of professional correctness. It must
@@ -168,7 +173,7 @@ Record each scenario, expected behavior, observed behavior, and conclusion. For
 each model run, record the evaluator model and any exposed capability-relevant
 configuration, including reasoning effort when available. For each
 lower-capability run, also record the basis for establishing that its model
-differs from the authoring model and is an applicable lower-capability baseline.
+differs from the comparison model and is an applicable lower-capability baseline.
 Static validation still checks frontmatter, links, formatting, metadata,
 packaging, and complete routes, but it cannot replace semantic evidence for
 behavior it does not execute. Compare the trusted pre-change and final bundles

--- a/references/agents/skill-authoring.md
+++ b/references/agents/skill-authoring.md
@@ -144,7 +144,31 @@ why it does not apply:
   declared inputs, material constraints, format, and completion gate rather than
   checking only that an artifact was emitted.
 
-Record the scenario, expected behavior, observed behavior, and conclusion.
+Run invocation and workflow evidence with a different supported model that is
+materially less capable for the evaluated task than the model used to author
+the change. Record the authoring model and any exposed capability-relevant
+configuration before selecting the evaluator. Choose a model that still has the
+required modalities, tools, and context, and justify its lower-capability
+baseline from relevant evidence rather than its name or price alone. A lower
+reasoning effort on the authoring model does not provide this cross-model
+evidence. Treat inability to establish the model comparison, or otherwise
+unavailable applicable cross-model evidence, as an incomplete result.
+
+Use the lower-capability run to test whether invocation and procedure are
+self-sufficient, not as the sole judgment of professional correctness. It must
+select or exclude the Skill correctly and either follow the applicable workflow
+through its claimed completion or take an explicit capability or stopping path
+defined by the Skill. Invented procedure, skipped investigation or decisions,
+and premature completion are failures rather than acceptable model limits. When
+the task itself exceeds the baseline model's capabilities, a correct explicit
+stop demonstrates instruction robustness; a capable evaluator must separately
+establish the procedure's correctness and the output evidence.
+
+Record each scenario, expected behavior, observed behavior, and conclusion. For
+each model run, record the evaluator model and any exposed capability-relevant
+configuration, including reasoning effort when available. For each
+lower-capability run, also record the basis for establishing that its model
+differs from the authoring model and is an applicable lower-capability baseline.
 Static validation still checks frontmatter, links, formatting, metadata,
 packaging, and complete routes, but it cannot replace semantic evidence for
 behavior it does not execute. Compare the trusted pre-change and final bundles


### PR DESCRIPTION
Skill behavioral evidence could previously be produced by the same highly capable model that authored the change. That allowed a Skill's triggers or procedures to depend on inference that less capable supported models could not reproduce.

This change identifies one task-specific comparison model for each applicable invocation or workflow scenario. Model-assisted authorship uses the most capable model that materially authored the behavior; human-only authorship uses the most capable supported model available to the authoring environment for the task. The evidence then runs on a different, task-relevant lower-capability model. It records the comparison and evaluator configurations, rejects same-model lower effort as cross-model evidence, distinguishes correct Skill-defined capability stops from procedural failures, and retains a capable evaluator for professional correctness and output evidence. The primary plugin version is `2026.9.9-2`.

## Design and behavioral evidence

- **User result and starting inputs:** A new or materially changed Skill must demonstrate that its invocation and procedure are self-sufficient across model capability, including underspecified requests, adjacent negative triggers, complex branches, missing evidence, and inherent task-capability limits.
- **Professional task and research:** The evidence model separates trigger and instruction robustness from substantive correctness. It selects one auditable comparison model for single-model, multi-model, or human-only authorship. A lower-capability baseline must still meet required modality, tool, and context constraints and be justified by task-relevant evidence rather than name or price. When the underlying task exceeds that baseline, only an explicit Skill-defined capability or stopping path can pass.
- **Responsibility boundary:** `references/agents/skill-authoring.md` already owns Skill behavioral evidence. The existing maintenance workflows consume that standard, so no duplicate rule or new route was added.
- **Invocation evidence:** Not separately applicable to this reference-only change because no Skill invocation condition changed.
- **Workflow evidence:** GPT-6 was the comparison model for this change; its reasoning effort was not exposed. A fresh `gpt-5.6-luna` evaluator at medium effort confirmed that same-model lower effort is insufficient, a correct explicit capability stop passes, invented or skipped procedure fails, unavailable comparison is incomplete, and an unevidenced cheap or differently named model does not qualify. It repeated the semantic comparison after every fix and found no remaining issue.
- **Correctness and output evidence:** A fresh `gpt-5.6-terra` evaluator at high effort first found missing authoring-side audit data and over-scoped output/human metadata. After correction, its repeated reviews found no remaining issue. A local `gpt-5.6-sol` high-effort attempt disconnected before producing evidence and was replaced by the successful Terra review.
- **Automated-review remediation:** The exact-head `gpt-5.6-sol` review on `07548ba` found that human-only and multi-model authorship lacked one deterministic comparison-model rule. Commit `a59e919` now uses the most capable materially authoring model, or the most capable supported model available to the authoring environment for human-only work. Both independent evaluators repeated their reviews with no findings.

## Validation

- `pnpm check` — passed, including 98 tests with no failures or skips
- `node .github/scripts/plugin-version/check.ts origin/main HEAD` — passed
- `git diff --check origin/main...HEAD` — passed
