### PR TITLE
Require observable postconditions for Skill actions

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.9.9-2",
+  "version": "2026.9.9-3",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }

--- a/references/agents/skill-authoring.md
+++ b/references/agents/skill-authoring.md
@@ -106,6 +106,18 @@ professional dimensions merely as optional examples when omitting them can
 prevent the promised result. At the same time, do not turn attention points
 into a fixed checklist when their relevance depends on the task.
 
+Bind each consequential action whose omission or incorrect execution could
+still leave a plausible-looking result to an observable postcondition before
+dependent work advances. Identify the acted-on object and revision when
+relevant, the expected postcondition, the observation that can establish it,
+and the reconciliation or stopping behavior for missing, partial,
+contradictory, or unknown results. Re-observe the actual state after the action
+and compare it with the postcondition before advancing. A plan or instruction
+to act, the Agent's memory or assertion, and the mere existence of an artifact
+are not evidence that the action completed. After an interruption or resumed
+run, re-observe current state from the last confirmed boundary before
+continuing.
+
 Define completion as the promised user result with its material constraints
 satisfied, not merely as producing a file, prompt, report, or other artifact.
 Include quality review or feasibility checks when a competent practitioner
@@ -139,7 +151,11 @@ why it does not apply:
 - **Workflow evidence:** exercise underspecified and already settled inputs, the
   principal complex branch, material conflicts or missing evidence, and inputs
   likely to tempt the Agent to skip investigation, decisions, or stopping
-  behavior.
+  behavior. When the task has consequential actions with observable
+  postconditions, include an applicable omitted, partial, interrupted,
+  wrong-target, or unknown-result action and verify that the workflow
+  re-observes, reconciles, or stops instead of advancing as though the action
+  completed.
 - **Output evidence:** verify the user-visible result, professional minimum,
   declared inputs, material constraints, format, and completion gate rather than
   checking only that an artifact was emitted.


### PR DESCRIPTION
## Problem and resulting behavior

A Skill can name an action and completion criteria while still allowing an Agent to advance from a plan, memory, assertion, or a plausible-looking artifact. Omitted, partial, wrong-target, interrupted, or unknown-result work can therefore appear complete.

This change requires each consequential action with that failure shape to have an observable postcondition before dependent work advances. The workflow must re-observe and compare actual state, define reconciliation or stopping behavior for inconclusive results, and re-establish state after interruption. Risk-derived workflow evidence must exercise an applicable failure case instead of proving only the happy path.

## Design and evidence

- **Task model:** Skill authors and reviewers need to distinguish a stated action from an action whose result was observed. The rule applies only when omission or incorrect execution can still leave a plausible result, preserving the existing prohibition on fixed checklists for context-dependent concerns.
- **Professional basis:** Railway point-and-call research ties confirmation to the object and its observed state, while NASA describes aviation challenge-response more precisely as challenge-verification-response. NASA interruption guidance also identifies loss of place in a procedure as an omission risk. Sources: [RTRI point-and-call study](https://www.jstage.jst.go.jp/article/rtriqr/53/4/53_231/_pdf/-char/en), [NASA flight-deck checklist study](https://ntrs.nasa.gov/api/citations/19910017830/downloads/19910017830.pdf), and [NASA ASRS interrupted-checklist guidance](https://asrs.arc.nasa.gov/publications/callback/cb_320.htm).
- **Responsibility and placement:** The existing shared `references/agents/skill-authoring.md` already owns executable workflow and behavioral-evidence requirements. Its current consumers and routes remain unchanged; no new Knowledge, runbook rule, Skill, or reference is introduced.
- **Behavioral review:** A first isolated semantic comparison found and scoped three issues: an overbroad action qualifier, failure to name plans explicitly, and missing partial-result handling. After correction, a second isolated comparison found all three resolved with no semantic loss, duplicate authority, unsupported constraint, or consumer-route change. Because this changes the authoring standard rather than a concrete Skill's invocation or execution, cross-model Skill runs do not apply to this PR.

## Validation

- `pnpm check`
- `git diff --check`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`
- two-pass independent semantic comparison against `origin/main`

Primary plugin version: `2026.9.9-3`.
