### PR TITLE
Treat timeout retries as overlap and require Knowledge dependency proof

### DIFF
--- a/.agents/skills/maintain-knowledge-base/references/maintain-knowledge.md
+++ b/.agents/skills/maintain-knowledge-base/references/maintain-knowledge.md
@@ -36,22 +36,49 @@
    routing catalog. Organize leaf documents in domain directories, but list
    every remaining leaf directly in the root index and do not create nested
    indexes or leaf-level `Related Knowledge`, `See also`, or similar routing
-   appendices. When one leaf genuinely depends on another, link it inline where
-   the dependency is applied and include the local context needed to use the
-   current document.
+   appendices. Before linking one leaf from another, apply the
+   [inline-dependency test](#admit-inline-knowledge-dependencies). Link a
+   retained dependency where it is applied and include the local context needed
+   to use the current document.
 10. Add, update, or remove the root-index row for every affected leaf document
     using the fields below, including its Knowledge Type. Repair every route
     and inline dependency affected by a move, merge, split, rename, or removal.
 11. Verify that every remaining leaf document is listed exactly once with one
     valid Knowledge Type, serves its `When to Read` condition without requiring
     another leaf as a prerequisite, contains no routing appendix, and resolves
-    every changed relative link. Confirm that each concept has one canonical
-    owner and each revised document presents one coherent current model.
-    Compare every changed Scope and routing trigger with its pre-edit form;
-    keep additions that express the same responsibility and route independent
-    responsibilities separately. Confirm that removed leaves and obsolete
-    routes no longer remain.
+    every changed relative link. Confirm that every added or materially changed
+    inline link between Knowledge leaves passes the inline-dependency test and
+    that its target fits the scope of the source claim. Confirm that each
+    concept has one canonical owner and each revised document presents one
+    coherent current model. Compare every changed Scope and routing trigger
+    with its pre-edit form; keep additions that express the same responsibility
+    and route independent responsibilities separately. Confirm that removed
+    leaves and obsolete routes no longer remain.
 12. Run `pnpm knowledge:check` from the repository root.
+
+## Admit inline Knowledge dependencies
+
+An inline link between Knowledge leaves records that a source claim depends on
+the target's canonical responsibility; it does not make the target prerequisite
+reading. The source must still state enough context to serve its own root-index
+route. Apply this deletion test before adding or retaining a link:
+
+1. Remove the link and its asserted dependency while preserving the source's
+   local explanation. Name the exact claim whose correctness, authority, or
+   application would change. If no source claim depends on the target, omit the
+   link.
+2. Confirm that the target's pre-edit Scope owns the premise, decision, or
+   mapping on which that source claim relies. State the context needed to apply
+   the dependency locally without duplicating the target's responsibility.
+3. Confirm that the dependency belongs to the source's pre-edit responsibility.
+   A sentence or branch whose only contribution is related reading, an optional
+   technique, or an independently retrievable language-, platform-, product-,
+   or implementation-specific specialization fails this check and should rely
+   on the target's root-index `When to Read` condition.
+
+Keep the link only when all three checks establish a dependency within the
+source responsibility. Related reading, optional techniques, and independently
+retrievable specializations remain separate Knowledge routes.
 
 ## Ownership and generalization
 

--- a/.agents/skills/maintain-knowledge-base/references/maintain-knowledge.md
+++ b/.agents/skills/maintain-knowledge-base/references/maintain-knowledge.md
@@ -63,15 +63,22 @@ the target's canonical responsibility; it does not make the target prerequisite
 reading. The source must still state enough context to serve its own root-index
 route. Apply this deletion test before adding or retaining a link:
 
+First fix the comparison boundary for both leaves. For an existing leaf, use
+its trusted pre-edit Scope, root-index `When to Read` condition, and
+responsibility. For a new leaf, use the responsibility, retrieval condition,
+consumers, and maintenance lifecycle established by classification before its
+content or links are drafted; its proposed Scope must express rather than widen
+that boundary.
+
 1. Remove the link and its asserted dependency while preserving the source's
    local explanation. Name the exact claim whose correctness, authority, or
    application would change. If no source claim depends on the target, omit the
    link.
-2. Confirm that the target's pre-edit Scope owns the premise, decision, or
-   mapping on which that source claim relies. State the context needed to apply
-   the dependency locally without duplicating the target's responsibility.
-3. Confirm that the dependency belongs to the source's pre-edit responsibility.
-   A sentence or branch whose only contribution is related reading, an optional
+2. Confirm that the target's comparison boundary owns the premise, decision,
+   or mapping on which that source claim relies. State the context needed to
+   apply the dependency locally without duplicating the target's responsibility.
+3. Confirm that the dependency belongs to the source's comparison boundary. A
+   sentence or branch whose only contribution is related reading, an optional
    technique, or an independently retrievable language-, platform-, product-,
    or implementation-specific specialization fails this check and should rely
    on the target's root-index `When to Read` condition.

--- a/.github/scripts/ai-review/prompts/review.md
+++ b/.github/scripts/ai-review/prompts/review.md
@@ -33,6 +33,17 @@ Review every applicable repository-specific dimension:
    Apply one only when the finding and its premises still match, and recheck it
    when its recorded trigger has occurred.
 
+For every added or materially changed inline link between Knowledge leaves,
+apply the
+[inline-dependency test](.agents/skills/maintain-knowledge-base/references/maintain-knowledge.md#admit-inline-knowledge-dependencies).
+Report a finding when no named source claim's correctness, authority, or
+application depends on the target; the target supplies related or optional
+material rather than a canonical premise, decision, or mapping on which that
+claim relies; or the pointer introduces an independently retrievable language-,
+platform-, product-, or implementation-specific branch. Accept the dependency
+only when it belongs within the source's existing scope and the source states
+enough local context to remain independently usable.
+
 Do not report a defect that a required CI check deterministically detects for
 the same revision. Still report behavior outside CI coverage, weakened or
 silently skipped validation, and semantic defects that mechanical checks miss.

--- a/.github/scripts/ai-review/prompts/review.md
+++ b/.github/scripts/ai-review/prompts/review.md
@@ -39,10 +39,12 @@ apply the
 Report a finding when no named source claim's correctness, authority, or
 application depends on the target; the target supplies related or optional
 material rather than a canonical premise, decision, or mapping on which that
-claim relies; or the pointer introduces an independently retrievable language-,
-platform-, product-, or implementation-specific branch. Accept the dependency
-only when it belongs within the source's existing scope and the source states
-enough local context to remain independently usable.
+claim relies; or the pointer's only contribution is an independently retrievable
+language-, platform-, product-, or implementation-specific branch. Accept the
+dependency only when it belongs within the source's accepted comparison
+boundary—its trusted pre-change responsibility for an existing leaf or its
+classified responsibility for a new leaf—and the source states enough local
+context to remain independently usable.
 
 Do not report a defect that a required CI check deterministically detects for
 the same revision. Still report behavior outside CI coverage, weakened or

--- a/knowledge/software-testing/trustworthy-test-execution.md
+++ b/knowledge/software-testing/trustworthy-test-execution.md
@@ -173,6 +173,50 @@ sensitivity are execution inputs, not portable constants. For filesystem
 namespace races, use the forced-interleaving techniques in
 [Pathnames and filesystem resource identity](../filesystems/pathnames-and-resource-identity.md).
 
+## Treat timeout retries as overlapping executions
+
+A timeout, abort result, or wrapper rejection that can settle independently of
+the underlying body establishes only that the runner stopped waiting. It does
+not by itself establish that the test body or any writer, request, timer,
+process, or external operation started by that attempt has settled. A test-body
+`finally` block is likewise not a runner completion barrier: the runner can
+begin hooks or return control while the original body continues toward that
+block independently.
+
+Apply the attempt's ownership boundary before a hook restores shared state,
+another case reuses it, or a retry starts. Request cancellation when the
+operation supports it, then await evidence that every attempt-owned actor can
+no longer read or mutate the prior state. A completion Promise is a barrier
+only when it settles after the effects and cleanup on which the caller relies;
+for JavaScript and TypeScript coordination, apply
+[JavaScript Promise coordination](../javascript/promises.md).
+
+When another attempt can start before that boundary, model the attempts as
+concurrent executions. Inventory every process singleton, environment value,
+fixture, namespace, process, port, file, database, remote operation, and
+external side effect that both can reach. Account for an earlier attempt that
+publishes a late result, performs late cleanup, or deletes or overwrites state
+already claimed by the replacement. Attempt-private mutable state is isolated
+only when the previous attempt can no longer reach it.
+
+Disable same-case retry when settlement cannot be established before the next
+attempt. This removes that retry path, but it does not stop the timed-out work
+or make hooks and later cases safe. When the runner cannot prevent continued
+same-worker execution until quiescence, replace the attempt only after
+terminating and confirming an isolation boundary that contains every relevant
+actor and effect. A worker or process exit does not settle detached descendants,
+server-side or remote work, or durable effects outside that boundary.
+
+When a test retry can repeat a state-changing operation whose effects survive
+the caller's timeout or disconnection, apply
+[Overlapping mutation admission](../software-design/overlapping-mutation-admission.md)
+at the effect-owning boundary. The operation still needs an applicable
+idempotency, conditional-mutation, ownership, or stale-execution contract.
+
+An ordinary failure can be retried sequentially when the attempt's true
+completion boundary has settled and cleanup has restored the declared
+baseline.
+
 ## Establish intermittent evidence
 
 Bind an intermittent outcome to an exact revision, command, failure signature,

--- a/knowledge/software-testing/trustworthy-test-execution.md
+++ b/knowledge/software-testing/trustworthy-test-execution.md
@@ -186,10 +186,9 @@ block independently.
 Apply the attempt's ownership boundary before a hook restores shared state,
 another case reuses it, or a retry starts. Request cancellation when the
 operation supports it, then await evidence that every attempt-owned actor can
-no longer read or mutate the prior state. A completion Promise is a barrier
-only when it settles after the effects and cleanup on which the caller relies;
-for JavaScript and TypeScript coordination, apply
-[JavaScript Promise coordination](../javascript/promises.md).
+no longer read or mutate the prior state. Treat a completion signal as a
+barrier only when it represents the effects and cleanup on which the caller
+relies.
 
 When another attempt can start before that boundary, model the attempts as
 concurrent executions. Inventory every process singleton, environment value,

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.9.9-4",
+  "version": "2026.9.11-1",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }


### PR DESCRIPTION
A runner can report a timeout while the timed-out attempt still owns active work. Starting a retry at that point creates concurrent execution over potentially shared process state, fixtures, and external effects. This change adds that missing execution rule and tightens the authoring and review paths after the initial implementation exposed an unnecessary language-specific Knowledge link.

## Changes

- treat retries that begin before the prior attempt's true completion boundary as overlapping executions
- require cancellation plus observed settlement before hooks, later cases, or retries reuse affected state
- distinguish disabling same-case retries from stopping timed-out work or protecting later tests
- qualify worker and process replacement by whether the isolation boundary contains every relevant actor and effect
- route persistent mutation safety to its existing framework-independent Knowledge owner
- preserve fully settled transient failures as an adjacent safe retry case
- keep the test-execution rule framework-independent by using a completion signal instead of a Promise-specific branch
- add an inline-dependency test to the Knowledge-maintenance workflow
- require the repository AI reviewer to apply that test to added or materially changed links between Knowledge leaves
- publish primary plugin version `2026.9.11-1`

The existing evergreen classification, Knowledge-index route, Scope, and installed consumers remain unchanged.

## Knowledge and workflow design

The timeout-retry rule belongs in the existing Trustworthy test execution leaf because its task-facing trigger already covers retries, concurrency, processes, shared state, cleanup, and timeouts. The root Knowledge index independently routes JavaScript and TypeScript Promise work, so the general leaf does not add a Promise specialization.

The maintenance reference owns author-time admission of cross-Knowledge dependencies. Its new deletion test requires a named source claim whose correctness, authority, or application depends on the target's canonical premise, decision, or mapping. It rejects related reading, optional techniques, and independently retrievable specializations while preserving valid canonical mappings with enough local context for each leaf to remain independently usable.

The repository AI-review prompt directly invokes the same authoritative test for every added or materially changed inline link. `AGENTS.md` remains unchanged because it already owns the architectural rule that the root index handles routing and inline links represent genuine dependencies.

## Behavioral evidence

Neutral checks with Node.js v26.8.1 observed that `afterEach` can begin before a timed-out asynchronous body reaches `finally`. Starting a manual second attempt after the timed-out subtest returned produced two simultaneously active attempts, while retrying after an ordinary fully settled failure kept the maximum active-attempt count at one.

The Agent-instruction change was exercised with the strongest available comparison model (`gpt-6-astra`, high reasoning) and a materially lower-capability model (`gpt-5.6-luna`, medium reasoning). Both models:

- rejected the Promise sentence and link when authoring the framework-independent test-execution rule;
- reported the historical `0e81cf0` Promise pointer as one concrete P2 review finding with the minimal completion-signal remediation;
- retained the valid Node.js filesystem-primitives mapping to the canonical general filesystem-identity invariants;
- allowed valid dependencies when either the source or target leaf is new by using the classification boundary fixed before drafting; and
- prevented a proposed Scope or link from widening that classified boundary.

An initial candidate correctly rejected the bad link but could also reject a valid canonical mapping. A fresh exact-head review then found that the rule had no satisfiable path when the source or target leaf was newly created. Commit `11eddf2` fixes that gap by establishing the comparison boundary from trusted pre-change responsibility for existing leaves or from classification completed before drafting for new leaves. The repeated comparison and lower-capability evaluations passed the bad-link, existing-mapping, new-source, and new-target scenarios without a blocking ambiguity.

The hosted AI review for this pull request reads repository criteria from the `pull_request_target` event base, so it cannot demonstrate the proposed review-prompt behavior on its own change. The synthetic read-only review provides the behavioral evidence here; a pull request opened or updated after this prompt reaches the default branch will exercise the deployed criterion.

An independent semantic comparison against `origin/main`, issue #111, the complete affected Knowledge leaf, maintenance reference, AI-review prompt, routes, and consumers found no unexplained loss, distortion, duplicate authority, scope expansion, or routing gap.

## Validation

- Skill `quick_validate.py` for `.agents/skills/maintain-knowledge-base`
- `pnpm prompt-links:check`
- `pnpm links:check`
- `pnpm check`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`
- `git diff --check origin/main...HEAD`
- neutral timeout/hook, overlapping-attempt, and settled-failure cases with Node.js v26.8.1
- comparison-model and lower-capability author/reviewer dependency scenarios
- independent whole-diff semantic comparison

Closes #111.
