### PR TITLE
Clarify generation fencing and orchestration test evidence

### DIFF
--- a/knowledge/javascript/promises.md
+++ b/knowledge/javascript/promises.md
@@ -81,7 +81,16 @@ const release = Promise.withResolvers<void>();
 This directly exercises cases such as one operation failing while a sibling
 remains in flight. `await Promise.resolve()` can advance already queued Promise
 reactions, but it is not a completion barrier for work that depends on later
-events, I/O, timers, or an external release. Apply
+events, I/O, timers, or an external release.
+
+Treat every externally settled test barrier as a test-owned asynchronous
+resource. Register its cleanup when it is created. On every exit, resolve or
+reject each outstanding barrier according to the test contract, await the
+operations that consume it until they settle, and only then discard resolver
+handles or reset fixture state. Dropping settlement-function references does
+not settle the Promise and can leave later work joined to a pending operation.
+
+Apply
 [Trustworthy test execution](../software-testing/trustworthy-test-execution.md)
 when the barrier participates in a broader asynchronous, timeout, retry, or
 cleanup test design.

--- a/knowledge/software-design/overlapping-mutation-admission.md
+++ b/knowledge/software-design/overlapping-mutation-admission.md
@@ -116,6 +116,24 @@ and reject effects from stale owners there. Define which finalization effects
 need the same protection. Time-based expiry improves recovery from abandoned
 ownership but does not by itself stop an earlier execution from continuing.
 
+A locally owned generation represents one semantic precondition, not a general
+indication that nearby state changed. Define the assumption associated with the
+generation and advance it only when an event makes work admitted under an
+earlier value stale. Cache eviction, refresh requests, recomputation, or changes
+to independently owned cached data must not advance an authority generation
+unless they invalidate that same assumption. When one reset spans independent
+state, split its invalidation effects or give the independently changing domains
+separate generations so unrelated changes do not widen the stale domain.
+
+When an authority-changing mutation is confirmed and operation-owned
+verification or reconciliation follows, advance the applicable generation at
+that confirmed mutation boundary before those later phases can overlap
+pre-mutation work. The exact boundary depends on the external mutation
+contract. When an effect may have occurred without confirmation, a later local
+generation change cannot close that uncertainty; use an atomic precondition or
+fence at the effect-owning boundary, or define how the ambiguous outcome is
+reconciled.
+
 ## Keep observation separate from admission
 
 Status endpoints, persisted operation records, pending indicators, and polling
@@ -135,8 +153,9 @@ A design or review should account for:
 4. when active ownership is used, the final operation-owned effect and every
    release path;
 5. cancellation, timeout, queueing, or supersession behavior that applies; and
-6. the mechanism that rejects stale mutation and, when ownership can transfer,
-   stale release.
+6. the semantic precondition represented by each generation or fence, the
+   events and boundary that advance it, and the mechanism that rejects stale
+   mutation and, when ownership can transfer, stale release.
 
 Review remains incomplete while a supported ingress or operation-owned phase is
 unaccounted for, unless evidence establishes that a second invocation cannot
@@ -151,6 +170,14 @@ precondition and assert which effects can commit. Exercise exceptional release
 and finalization ownership when they can violate the contract. Add a composed
 test when separate ingresses must converge on the same owner, and keep the
 detailed cases at the narrowest seam that owns admission.
+
+When a generation protects publication from work admitted under an authority
+snapshot, test both sides of its scope. Hold valid work across an unrelated
+cache reset and prove that it remains valid. For a real authority change,
+complete the replacement work before releasing the pre-mutation work and prove
+that the stale completion cannot publish. When operation-owned verification
+follows the mutation, observe that the generation has already advanced before
+verification begins.
 
 For JavaScript and TypeScript barriers, apply [JavaScript Promise coordination](../javascript/promises.md).
 Apply [Test effectiveness](../software-testing/test-effectiveness.md) to select

--- a/knowledge/software-testing/test-effectiveness.md
+++ b/knowledge/software-testing/test-effectiveness.md
@@ -121,6 +121,25 @@ When one contract requires both a retained capability and the absence of a
 secondary authority, fallback, mutation, or side effect, assert both and keep a
 positive control that proves the fixture can exercise the capability.
 
+For orchestration that forwards values returned by collaborators, a call
+assertion proves the interaction but not that the returned value reached the
+downstream decision. For each independently meaningful forwarded value, name a
+plausible wiring fault such as omission, substitution with another snapshot or
+context, or swapping two results. Choose fixture values for which correct and
+faulty forwarding produce different outcomes at the seam that owns the
+decision, and assert that semantic outcome. Treat call and argument assertions
+as supplemental unless the interaction itself is the owned contract. Use
+separate focused scenarios when one fixture cannot distinguish every forwarded
+value, and apply [controlled mutation evidence](#prove-the-test-has-teeth) when
+the protection remains uncertain.
+
+For example, current configuration can leave an input unclassified while
+historical configuration explicitly selects no action. Correctly forwarding
+the historical result selects no action, while omitting it produces the
+unclassified-input failure. If current and historical fixtures instead produce
+the same decision, the expected result cannot establish which value was
+forwarded.
+
 Cover detailed state combinations at the narrowest seam that owns the decision.
 Add a representative composed or end-to-end scenario when the fault depends on
 cross-boundary wiring, selecting the highest-risk user-observable state supported

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "knowledge-base",
-  "version": "2026.9.11-1",
+  "version": "2026.9.12-1",
   "description": "A personal knowledge base with reusable Agent workflows.",
   "repository": "https://github.com/Soulike/knowledge-base"
 }


### PR DESCRIPTION
## Problem and result

Generation counters could invalidate work for unrelated cache changes, Promise test barriers could remain pending after abnormal exits, and orchestration tests could prove collaborator invocation without proving that returned values reached the owning decision.

This change scopes locally owned generations to their semantic preconditions and confirmed mutation boundary, adds two-sided stale-publication tests, requires externally settled Promise barriers to be settled and awaited before fixture reuse, and makes orchestration fixtures distinguish correct result propagation from omission or substitution. The existing Knowledge owners and index routes remain unchanged.

The primary plugin version is updated to `2026.9.12-1`.

Closes #114
Closes #115

## Validation

- `pnpm check`
- `node .github/scripts/plugin-version/check.ts origin/main HEAD`
- `git diff --check origin/main...HEAD`
- Independent semantic comparison against `origin/main`, both issue proposals, and their accepted maintainer evaluations found no missing, distorted, duplicated, or over-generalized responsibility.
